### PR TITLE
Refactor bottom message to reuse top logo section

### DIFF
--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -19,3 +19,4 @@
 17. 2025-08-12: Genericized opt-in option labels, documented form layout guidelines, and redesigned top message with video, premium pitch, and logo.
 18. 2025-08-12: Refactored top banner into two-column layout, moved upgrade button beneath text, and added centered logo row with contact links.
 19. 2025-08-12: Replaced bottom message with logo row variant and added digital marketing section class.
+20. 2025-08-12: Removed top logo row, added thank-you tagline to bottom message, and cleaned up unused premium logo styles.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -20,3 +20,4 @@
 18. 2025-08-12: Refactored top banner into two-column layout, moved upgrade button beneath text, and added centered logo row with contact links.
 19. 2025-08-12: Replaced bottom message with logo row variant and added digital marketing section class.
 20. 2025-08-12: Removed top logo row, added thank-you tagline to bottom message, and cleaned up unused premium logo styles.
+21. 2025-08-12: Reintroduced logos, added US states and territories placeholder, and refreshed styles and scripts.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -18,3 +18,4 @@
 16. 2025-08-12: Renamed initial field to Placeholder 1, shifted labels through Placeholder 27, and fixed the color picker width.
 17. 2025-08-12: Genericized opt-in option labels, documented form layout guidelines, and redesigned top message with video, premium pitch, and logo.
 18. 2025-08-12: Refactored top banner into two-column layout, moved upgrade button beneath text, and added centered logo row with contact links.
+19. 2025-08-12: Replaced bottom message with logo row variant and added digital marketing section class.

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -136,12 +136,6 @@
     background: #00976c;
 }
 
-.cpb-bottom-message {
-    padding: 10px;
-    background: #f1f1f1;
-    margin: 10px 0;
-}
-
 #cpb-spinner {
     display: none;
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -74,22 +74,10 @@
     border: 0;
 }
 
-.cpb-premium-logo {
-    width: 160px;
-}
-
 .cpb-top-left p {
     text-align: center;
     margin-top: 8px;
     color:rgba(1, 58, 81, 1.0);
-}
-
-.cpb-premium-logo {
-    max-width: 60%;
-    height: auto;
-    display: block;
-    margin: 0 auto;
-    margin-bottom: 20px;
 }
 
 .cpb-top-logo-row {
@@ -104,18 +92,6 @@
     font-size: 13px;
     margin-bottom:0;
 }
-.cpb-top-left p {
-    text-align: center;
-    margin-top: 8px;
-}
-
-.cpb-premium-logo {
-    max-width: 100%;
-    height: auto;
-    display: block;
-    margin: 0 auto;
-}
-
 .cpb-upgrade-button {
     display: inline-block;
     margin-top: 8px;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -35,6 +35,7 @@
     gap: 20px;
     padding-left: 20px;
     padding-right: 20px;
+    padding-bottom:20px;
 }
 
 .cpb-top-left,
@@ -50,7 +51,7 @@
     font-size:16px;
 }
 
-.cpb-top-right p, .cpb-top-tagline{
+.cpb-top-right p, .cpb-top-tagline, .cpb-thanks-message{
     color: #013a51;
 }
 
@@ -80,6 +81,13 @@
     color:rgba(1, 58, 81, 1.0);
 }
 
+.cpb-premium-logo {
+    max-width: 100%;
+    height: auto;
+    display: block;
+    margin: 0 auto 20px;
+}
+
 .cpb-top-logo-row {
     text-align: center;
     background-color: #f2f4e8;
@@ -91,6 +99,10 @@
     margin-top: 8px;
     font-size: 13px;
     margin-bottom:0;
+}
+
+.cpb-bottom-message-digital-marketing-section{
+    padding:0px;
 }
 .cpb-upgrade-button {
     display: inline-block;

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -37,7 +37,7 @@ jQuery(document).ready(function($){
                     var $content=$('<div class="item-content"></div>');
                     cpbAdmin.placeholders.forEach(function(label,index){
                         var key='placeholder_'+(index+1);
-                    if(index===25){
+                    if(index===26){
                         var urlKey='placeholder_'+(index+1)+'_url';
                             if(ent[urlKey]){
                                 $content.append('<p><img src="'+ent[urlKey]+'" style="max-width:100px;height:auto;" /></p>');
@@ -76,7 +76,7 @@ jQuery(document).ready(function($){
     $(document).on('click','#cpb-add-item',function(){
         var count = $('#cpb-items-container .cpb-item-row').length + 1;
         var row = $('<div class="cpb-item-row" style="margin-bottom:8px; display:flex; align-items:center;"></div>');
-          row.append('<input type="text" name="placeholder_24[]" class="regular-text cpb-item-field" placeholder="'+cpbAdmin.itemPlaceholder.replace('%d',count)+'" />');
+          row.append('<input type="text" name="placeholder_25[]" class="regular-text cpb-item-field" placeholder="'+cpbAdmin.itemPlaceholder.replace('%d',count)+'" />');
         row.append('<button type="button" class="cpb-delete-item" aria-label="Remove" style="background:none;border:none;cursor:pointer;margin-left:8px;"><span class="dashicons dashicons-no-alt"></span></button>');
         $('#cpb-items-container').append(row);
     });

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -63,7 +63,7 @@ class CPB_Admin {
 
     private function get_placeholder_labels() {
         $labels = array();
-        for ( $i = 1; $i <= 27; $i++ ) {
+        for ( $i = 1; $i <= 28; $i++ ) {
             $labels[] = sprintf( __( 'Placeholder %d', 'codex-plugin-boilerplate' ), $i );
         }
         return $labels;
@@ -124,9 +124,23 @@ class CPB_Admin {
         );
     }
 
+    private function get_us_states_and_territories() {
+        return array_merge(
+            $this->get_us_states(),
+            array(
+                __( 'District of Columbia', 'codex-plugin-boilerplate' ),
+                __( 'American Samoa', 'codex-plugin-boilerplate' ),
+                __( 'Guam', 'codex-plugin-boilerplate' ),
+                __( 'Northern Mariana Islands', 'codex-plugin-boilerplate' ),
+                __( 'Puerto Rico', 'codex-plugin-boilerplate' ),
+                __( 'U.S. Virgin Islands', 'codex-plugin-boilerplate' ),
+            )
+        );
+    }
+
     private function get_tooltips() {
         $tooltips = array();
-        for ( $i = 1; $i <= 27; $i++ ) {
+        for ( $i = 1; $i <= 28; $i++ ) {
             $tooltips[ 'placeholder_' . $i ] = sprintf(
                 __( 'Tooltip placeholder text for Placeholder %d', 'codex-plugin-boilerplate' ),
                 $i
@@ -150,6 +164,7 @@ class CPB_Admin {
         );
         echo '<p>' . wp_kses_post( $upgrade_text ) . '</p>';
         echo '<a class="cpb-upgrade-button" href="https://levelupmarketers.com" target="_blank">' . esc_html__( 'Upgrade Now', 'codex-plugin-boilerplate' ) . '</a>';
+        echo '<a href="https://levelupmarketers.com" target="_blank"><img src="' . esc_url( CPB_PLUGIN_URL . 'assets/images/levelup-logo.svg' ) . '" alt="' . esc_attr__( 'Level Up Digital Marketing logo', 'codex-plugin-boilerplate' ) . '" class="cpb-premium-logo" /></a>';
         echo '</div>';
         echo '</div>';
         echo '</div>';
@@ -162,12 +177,13 @@ class CPB_Admin {
 
         echo '<div class="cpb-top-message cpb-bottom-message-digital-marketing-section">';
         echo '<div class="cpb-top-logo-row">';
+        echo '<a href="https://levelupmarketers.com" target="_blank"><img src="' . esc_url( CPB_PLUGIN_URL . 'assets/images/levelup-logo.svg' ) . '" alt="' . esc_attr__( 'Level Up Digital Marketing logo', 'codex-plugin-boilerplate' ) . '" class="cpb-premium-logo" /></a>';
         $thanks = sprintf(
             /* translators: %s: Plugin name. */
             __( 'Thanks SO MUCH for using %s - a Level Up plugin!', 'codex-plugin-boilerplate' ),
             esc_html( $plugin_name )
         );
-        echo wp_kses_post( $thanks ) . '<br />';
+        echo '<p class="cpb-thanks-message">' . wp_kses_post( $thanks ) . '</p>';
         $tagline = sprintf(
             __( 'Need marketing or custom software development help? Email %1$s or call %2$s now!', 'codex-plugin-boilerplate' ),
             '<a href="mailto:contact@levelupmarketers.com">contact@levelupmarketers.com</a>',
@@ -352,12 +368,19 @@ class CPB_Admin {
             array(
                 'name'    => 'placeholder_21',
                 'label'   => __( 'Placeholder 21', 'codex-plugin-boilerplate' ),
-                'type'    => 'text',
+                'type'    => 'state',
+                'options' => $this->get_us_states_and_territories(),
                 'tooltip' => $tooltips['placeholder_21'],
             ),
             array(
                 'name'    => 'placeholder_22',
                 'label'   => __( 'Placeholder 22', 'codex-plugin-boilerplate' ),
+                'type'    => 'text',
+                'tooltip' => $tooltips['placeholder_22'],
+            ),
+            array(
+                'name'    => 'placeholder_23',
+                'label'   => __( 'Placeholder 23', 'codex-plugin-boilerplate' ),
                 'type'    => 'radio',
                 'options' => array(
                     'option1' => array(
@@ -373,37 +396,38 @@ class CPB_Admin {
                         'tooltip' => __( 'Tooltip placeholder text for Placeholder 22 Option 3', 'codex-plugin-boilerplate' ),
                     ),
                 ),
-                'tooltip' => $tooltips['placeholder_22'],
-            ),
-            array(
-                'name'    => 'placeholder_23',
-                'label'   => __( 'Placeholder 23', 'codex-plugin-boilerplate' ),
-                'type'    => 'opt_in',
                 'tooltip' => $tooltips['placeholder_23'],
             ),
             array(
                 'name'    => 'placeholder_24',
                 'label'   => __( 'Placeholder 24', 'codex-plugin-boilerplate' ),
-                'type'    => 'items',
+                'type'    => 'opt_in',
                 'tooltip' => $tooltips['placeholder_24'],
             ),
             array(
                 'name'    => 'placeholder_25',
                 'label'   => __( 'Placeholder 25', 'codex-plugin-boilerplate' ),
-                'type'    => 'color',
+                'type'    => 'items',
                 'tooltip' => $tooltips['placeholder_25'],
             ),
             array(
                 'name'    => 'placeholder_26',
                 'label'   => __( 'Placeholder 26', 'codex-plugin-boilerplate' ),
-                'type'    => 'image',
+                'type'    => 'color',
+                'attrs'   => 'value="#000000"',
                 'tooltip' => $tooltips['placeholder_26'],
             ),
             array(
                 'name'    => 'placeholder_27',
                 'label'   => __( 'Placeholder 27', 'codex-plugin-boilerplate' ),
-                'type'    => 'editor',
+                'type'    => 'image',
                 'tooltip' => $tooltips['placeholder_27'],
+            ),
+            array(
+                'name'    => 'placeholder_28',
+                'label'   => __( 'Placeholder 28', 'codex-plugin-boilerplate' ),
+                'type'    => 'editor',
+                'tooltip' => $tooltips['placeholder_28'],
                 'full_width' => true,
             ),
         );
@@ -428,7 +452,7 @@ class CPB_Admin {
                     echo '</select>';
                     break;
                 case 'state':
-                    $states = $this->get_us_states();
+                    $states = isset( $field['options'] ) ? $field['options'] : $this->get_us_states();
                     echo '<select name="' . esc_attr( $field['name'] ) . '">';
                     echo '<option value="" disabled selected>' . esc_html__( 'Make a Selection...', 'codex-plugin-boilerplate' ) . '</option>';
                     foreach ( $states as $state ) {

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -152,24 +152,24 @@ class CPB_Admin {
         echo '<a class="cpb-upgrade-button" href="https://levelupmarketers.com" target="_blank">' . esc_html__( 'Upgrade Now', 'codex-plugin-boilerplate' ) . '</a>';
         echo '</div>';
         echo '</div>';
-        echo '<div class="cpb-top-logo-row">';
-        echo '<a href="https://levelupmarketers.com" target="_blank"><img src="' . esc_url( CPB_PLUGIN_URL . 'assets/images/levelup-logo.svg' ) . '" alt="Level Up Digital Marketing logo" class="cpb-premium-logo" /></a>';
-        $tagline = sprintf(
-            __( 'A Level Up Plugin. Need marketing or custom software development help? Email %1$s or call %2$s now!', 'codex-plugin-boilerplate' ),
-            '<a href="mailto:contact@levelupmarketers.com">contact@levelupmarketers.com</a>',
-            '<a href="tel:18044898188">(804) 489-8188</a>'
-        );
-        echo '<p class="cpb-top-tagline">' . wp_kses_post( $tagline ) . '</p>';
-        echo '</div>';
         echo '</div>';
     }
 
     private function bottom_message_center() {
+        include_once ABSPATH . 'wp-admin/includes/plugin.php';
+        $plugin_data = get_plugin_data( CPB_PLUGIN_DIR . 'codex-plugin-boilerplate.php' );
+        $plugin_name = $plugin_data['Name'];
+
         echo '<div class="cpb-top-message cpb-bottom-message-digital-marketing-section">';
         echo '<div class="cpb-top-logo-row">';
-        echo '<a href="https://levelupmarketers.com" target="_blank"><img src="' . esc_url( CPB_PLUGIN_URL . 'assets/images/levelup-logo.svg' ) . '" alt="Level Up Digital Marketing logo" class="cpb-premium-logo" /></a>';
+        $thanks = sprintf(
+            /* translators: %s: Plugin name. */
+            __( 'Thanks SO MUCH for using %s - a Level Up plugin!', 'codex-plugin-boilerplate' ),
+            esc_html( $plugin_name )
+        );
+        echo wp_kses_post( $thanks ) . '<br />';
         $tagline = sprintf(
-            __( 'A Level Up Plugin. Need marketing or custom software development help? Email %1$s or call %2$s now!', 'codex-plugin-boilerplate' ),
+            __( 'Need marketing or custom software development help? Email %1$s or call %2$s now!', 'codex-plugin-boilerplate' ),
             '<a href="mailto:contact@levelupmarketers.com">contact@levelupmarketers.com</a>',
             '<a href="tel:18044898188">(804) 489-8188</a>'
         );

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -165,8 +165,16 @@ class CPB_Admin {
     }
 
     private function bottom_message_center() {
-        echo '<div class="cpb-bottom-message">';
-        echo '<p><a href="https://levelupmarketers.com" target="_blank">' . esc_html__( 'Upgrade for more features', 'codex-plugin-boilerplate' ) . '</a></p>';
+        echo '<div class="cpb-top-message cpb-bottom-message-digital-marketing-section">';
+        echo '<div class="cpb-top-logo-row">';
+        echo '<a href="https://levelupmarketers.com" target="_blank"><img src="' . esc_url( CPB_PLUGIN_URL . 'assets/images/levelup-logo.svg' ) . '" alt="Level Up Digital Marketing logo" class="cpb-premium-logo" /></a>';
+        $tagline = sprintf(
+            __( 'A Level Up Plugin. Need marketing or custom software development help? Email %1$s or call %2$s now!', 'codex-plugin-boilerplate' ),
+            '<a href="mailto:contact@levelupmarketers.com">contact@levelupmarketers.com</a>',
+            '<a href="tel:18044898188">(804) 489-8188</a>'
+        );
+        echo '<p class="cpb-top-tagline">' . wp_kses_post( $tagline ) . '</p>';
+        echo '</div>';
         echo '</div>';
     }
 


### PR DESCRIPTION
## Summary
- Replace bottom message markup with top message variant that retains logo row and tagline, adding `cpb-bottom-message-digital-marketing-section`.
- Remove obsolete `.cpb-bottom-message` styling from admin CSS.
- Document change in development diary.

## Testing
- `find . -name "*.php" -not -path "*/vendor/*" -print0 | xargs -0 -n1 php -l`


------
https://chatgpt.com/codex/tasks/task_e_689b6b353f988320ba7dcce3363ed4df