### PR TITLE
Add API Settings tab with accordion credential forms

### DIFF
--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -73,3 +73,4 @@
 70. 2025-11-10: Eliminated deprecated sleep warnings, extended the log helper for payment scopes, and added Payment Logs with clear/download tools; future payment integrations should capture full transaction context (names, contact info, purchase details, WordPress user data, allowed card fragments) while excluding sensitive card numbers.
 71. 2025-11-10: Normalized placeholder label and value sanitization so apostrophes, dashes, and other legitimate characters save and render consistently across Main Entity forms and related tooling.
 72. 2025-11-10: Added a Main Entity search dashboard with placeholder filters, inline spinner feedback, and paginated AJAX reads that honor active criteria.
+73. 2025-11-10: Added a Clear Search control to reset Main Entity filters and reload the default paginated results.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -64,4 +64,5 @@
 62. 2025-11-05: Cleared the email template action cell width constraints so the tab inherits the default table alignment.
 63. 2025-11-05: Built the Email Logs tab with file-backed delivery history, styled entry cards, and clear/download controls wired to AJAX and admin-post handlers.
 64. 2025-11-10: Introduced the API Settings tab with accordion-styled credential forms, reveal toggles, and inline feedback controls mirroring other admin sections.
+65. 2025-11-10: Added a Category column to the API Settings accordion headers and styled the cells to accommodate service group labels.
 

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -65,4 +65,5 @@
 63. 2025-11-05: Built the Email Logs tab with file-backed delivery history, styled entry cards, and clear/download controls wired to AJAX and admin-post handlers.
 64. 2025-11-10: Introduced the API Settings tab with accordion-styled credential forms, reveal toggles, and inline feedback controls mirroring other admin sections.
 65. 2025-11-10: Added a Category column to the API Settings accordion headers and styled the cells to accommodate service group labels.
+66. 2025-11-10: Scoped the API Settings accordion headers to use table-cell alignment, enforced a 50px row height, and right-aligned the action heading for consistent spacing.
 

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -78,3 +78,4 @@
 75. 2025-11-10: Surfaced logging status indicators across communications and log tabs with styled settings links so admins can confirm which channels are currently recording entries.
 76. 2025-11-10: Moved the payment log status indicator inside the log section so its layout matches the error log scopes while keeping other tabs unchanged.
 77. 2025-11-11: Normalized error logger keyword matching to stringify stack traces and messages so array data no longer triggers PHP type errors during log writes.
+78. 2025-11-11: Hardened error log helper formatting by stringifying complex values before sanitization to prevent array-to-string warnings when writing entries.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -75,3 +75,4 @@
 72. 2025-11-10: Added a Main Entity search dashboard with placeholder filters, inline spinner feedback, and paginated AJAX reads that honor active criteria.
 73. 2025-11-10: Added a Clear Search control to reset Main Entity filters and reload the default paginated results.
 74. 2025-11-10: Added general settings toggles for all logging channels, persisted preferences via AJAX, and gated email/error log writers behind the new helper so disabled logs stop recording immediately.
+75. 2025-11-10: Surfaced logging status indicators across communications and log tabs with styled settings links so admins can confirm which channels are currently recording entries.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -72,3 +72,4 @@
 69. 2025-11-10: Introduced error logging with sitewide and CPB-specific tabs, AJAX clear/download controls, and global handlers that track current and future plugin features.
 70. 2025-11-10: Eliminated deprecated sleep warnings, extended the log helper for payment scopes, and added Payment Logs with clear/download tools; future payment integrations should capture full transaction context (names, contact info, purchase details, WordPress user data, allowed card fragments) while excluding sensitive card numbers.
 71. 2025-11-10: Normalized placeholder label and value sanitization so apostrophes, dashes, and other legitimate characters save and render consistently across Main Entity forms and related tooling.
+72. 2025-11-10: Added a Main Entity search dashboard with placeholder filters, inline spinner feedback, and paginated AJAX reads that honor active criteria.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -77,3 +77,4 @@
 74. 2025-11-10: Added general settings toggles for all logging channels, persisted preferences via AJAX, and gated email/error log writers behind the new helper so disabled logs stop recording immediately.
 75. 2025-11-10: Surfaced logging status indicators across communications and log tabs with styled settings links so admins can confirm which channels are currently recording entries.
 76. 2025-11-10: Moved the payment log status indicator inside the log section so its layout matches the error log scopes while keeping other tabs unchanged.
+77. 2025-11-11: Normalized error logger keyword matching to stringify stack traces and messages so array data no longer triggers PHP type errors during log writes.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -74,3 +74,4 @@
 71. 2025-11-10: Normalized placeholder label and value sanitization so apostrophes, dashes, and other legitimate characters save and render consistently across Main Entity forms and related tooling.
 72. 2025-11-10: Added a Main Entity search dashboard with placeholder filters, inline spinner feedback, and paginated AJAX reads that honor active criteria.
 73. 2025-11-10: Added a Clear Search control to reset Main Entity filters and reload the default paginated results.
+74. 2025-11-10: Added general settings toggles for all logging channels, persisted preferences via AJAX, and gated email/error log writers behind the new helper so disabled logs stop recording immediately.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -63,4 +63,5 @@
 61. 2025-11-05: Scoped email template header cells to remove flex alignment and enforce a 50px row height without affecting other accordion tabs.
 62. 2025-11-05: Cleared the email template action cell width constraints so the tab inherits the default table alignment.
 63. 2025-11-05: Built the Email Logs tab with file-backed delivery history, styled entry cards, and clear/download controls wired to AJAX and admin-post handlers.
+64. 2025-11-10: Introduced the API Settings tab with accordion-styled credential forms, reveal toggles, and inline feedback controls mirroring other admin sections.
 

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -67,4 +67,5 @@
 65. 2025-11-10: Added a Category column to the API Settings accordion headers and styled the cells to accommodate service group labels.
 66. 2025-11-10: Scoped the API Settings accordion headers to use table-cell alignment, enforced a 50px row height, and right-aligned the action heading for consistent spacing.
 67. 2025-11-10: Wired API Settings forms to AJAX persistence with per-integration sanitization, inline feedback reuse, and saved credential prefills.
+68. 2025-11-10: Added an SMS Service accordion with generic messaging credentials and select-driven environments alongside existing API settings.
 

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -66,4 +66,5 @@
 64. 2025-11-10: Introduced the API Settings tab with accordion-styled credential forms, reveal toggles, and inline feedback controls mirroring other admin sections.
 65. 2025-11-10: Added a Category column to the API Settings accordion headers and styled the cells to accommodate service group labels.
 66. 2025-11-10: Scoped the API Settings accordion headers to use table-cell alignment, enforced a 50px row height, and right-aligned the action heading for consistent spacing.
+67. 2025-11-10: Wired API Settings forms to AJAX persistence with per-integration sanitization, inline feedback reuse, and saved credential prefills.
 

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -71,3 +71,4 @@
 
 69. 2025-11-10: Introduced error logging with sitewide and CPB-specific tabs, AJAX clear/download controls, and global handlers that track current and future plugin features.
 70. 2025-11-10: Eliminated deprecated sleep warnings, extended the log helper for payment scopes, and added Payment Logs with clear/download tools; future payment integrations should capture full transaction context (names, contact info, purchase details, WordPress user data, allowed card fragments) while excluding sensitive card numbers.
+71. 2025-11-10: Normalized placeholder label and value sanitization so apostrophes, dashes, and other legitimate characters save and render consistently across Main Entity forms and related tooling.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -70,3 +70,4 @@
 68. 2025-11-10: Added an SMS Service accordion with generic messaging credentials and select-driven environments alongside existing API settings.
 
 69. 2025-11-10: Introduced error logging with sitewide and CPB-specific tabs, AJAX clear/download controls, and global handlers that track current and future plugin features.
+70. 2025-11-10: Eliminated deprecated sleep warnings, extended the log helper for payment scopes, and added Payment Logs with clear/download tools; future payment integrations should capture full transaction context (names, contact info, purchase details, WordPress user data, allowed card fragments) while excluding sensitive card numbers.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -69,3 +69,4 @@
 67. 2025-11-10: Wired API Settings forms to AJAX persistence with per-integration sanitization, inline feedback reuse, and saved credential prefills.
 68. 2025-11-10: Added an SMS Service accordion with generic messaging credentials and select-driven environments alongside existing API settings.
 
+69. 2025-11-10: Introduced error logging with sitewide and CPB-specific tabs, AJAX clear/download controls, and global handlers that track current and future plugin features.

--- a/DEV_DIARY.md
+++ b/DEV_DIARY.md
@@ -76,3 +76,4 @@
 73. 2025-11-10: Added a Clear Search control to reset Main Entity filters and reload the default paginated results.
 74. 2025-11-10: Added general settings toggles for all logging channels, persisted preferences via AJAX, and gated email/error log writers behind the new helper so disabled logs stop recording immediately.
 75. 2025-11-10: Surfaced logging status indicators across communications and log tabs with styled settings links so admins can confirm which channels are currently recording entries.
+76. 2025-11-10: Moved the payment log status indicator inside the log section so its layout matches the error log scopes while keeping other tabs unchanged.

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -306,6 +306,91 @@
     margin-top: 24px;
 }
 
+.cpb-entity-search {
+    margin-bottom: 16px;
+    padding: 16px;
+    background: #ffffff;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+}
+
+.cpb-entity-search__title {
+    margin: 0 0 8px;
+    font-size: 16px;
+    line-height: 1.4;
+}
+
+.cpb-entity-search__description {
+    margin: 0 0 16px;
+    color: #50575e;
+}
+
+.cpb-entity-search__fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+}
+
+.cpb-entity-search__field {
+    flex: 1 1 220px;
+    min-width: 200px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.cpb-entity-search__label {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.cpb-entity-search__field .regular-text {
+    max-width: 100%;
+}
+
+.cpb-entity-search__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    flex-wrap: wrap;
+    margin-top: 8px;
+}
+
+.cpb-entity-search__actions .button {
+    margin: 0;
+}
+
+.cpb-entity-search__form .cpb-feedback-area {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cpb-entity-search__form .cpb-feedback-area .spinner {
+    margin: 0;
+}
+
+.cpb-entity-search__form .cpb-feedback-area [role="status"] {
+    display: none;
+    font-weight: 500;
+    color: #1d2327;
+}
+
+.cpb-entity-search__form .cpb-feedback-area [role="status"].is-visible {
+    display: inline;
+}
+
+@media (max-width: 782px) {
+    .cpb-entity-search__field {
+        flex: 1 1 100%;
+    }
+
+    .cpb-entity-search__actions {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+}
+
 .cpb-communications .description {
     margin-bottom: 16px;
 }

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -150,6 +150,43 @@
     color: #3c434a;
     max-width: 880px;
 }
+
+.cpb-log-status {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    background-color: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    padding: 12px 16px;
+    margin: 12px 0 16px;
+}
+
+.cpb-log-status__indicator {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background-color: #b32d2e;
+    flex-shrink: 0;
+}
+
+.cpb-log-status--enabled .cpb-log-status__indicator {
+    background-color: #008a20;
+}
+
+.cpb-log-status--disabled .cpb-log-status__indicator {
+    background-color: #b32d2e;
+}
+
+.cpb-log-status__message {
+    margin: 0;
+    font-size: 14px;
+    color: #1d2327;
+}
+
+.cpb-log-status__message a {
+    text-decoration: underline;
+}
 .cpb-upgrade-button {
     display: inline-block;
     margin-top: 8px;

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -173,7 +173,8 @@
 #cpb-create-form .submit,
 #cpb-general-settings-form .submit,
 #cpb-style-settings-form .submit,
-.cpb-entity-edit-form .submit {
+.cpb-entity-edit-form .submit,
+.cpb-api-settings__form .submit {
     display: flex;
     align-items: center;
     gap: 12px;
@@ -195,8 +196,50 @@
 #cpb-create-form .submit .cpb-feedback-area--inline,
 #cpb-general-settings-form .submit .cpb-feedback-area--inline,
 #cpb-style-settings-form .submit .cpb-feedback-area--inline,
-.cpb-entity-edit-form .submit .cpb-feedback-area--inline {
+.cpb-entity-edit-form .submit .cpb-feedback-area--inline,
+.cpb-api-settings__form .submit .cpb-feedback-area--inline {
     margin-left: 0;
+}
+
+.cpb-api-settings__fields {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 16px;
+    margin-top: 12px;
+}
+
+.cpb-api-settings__field {
+    flex: 1 1 220px;
+    min-width: 220px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+}
+
+.cpb-api-settings__field label {
+    font-weight: 600;
+    color: #1d2327;
+}
+
+.cpb-api-settings__form select,
+.cpb-api-settings__form .regular-text {
+    width: 100%;
+    max-width: 100%;
+}
+
+.cpb-api-settings__input-group {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cpb-api-settings__input-group .regular-text {
+    flex: 1 1 auto;
+}
+
+.cpb-api-settings__input-group .button {
+    flex: 0 0 auto;
+    white-space: nowrap;
 }
 
 .cpb-feedback-area--block {

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -333,8 +333,18 @@
     width: 20%;
 }
 
+.cpb-accordion__heading--category {
+    width: 18%;
+    min-width: 160px;
+}
+
 .cpb-accordion__heading--actions {
     text-align: right;
+}
+
+.cpb-accordion__cell--category {
+    color: #3c434a;
+    min-width: 160px;
 }
 
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -360,6 +360,10 @@
     min-height: 50px;
 }
 
+.cpb-communications--api-settings .cpb-accordion__summary-row > .cpb-accordion__cell {
+    height: 50px;
+}
+
 .cpb-accordion__summary-row:not(:first-of-type) > .cpb-accordion__cell {
     border-top: 10px solid #f6f7f7;
 }
@@ -386,6 +390,11 @@
     gap: 8px;
 }
 
+.cpb-communications--api-settings .cpb-accordion__cell--title,
+.cpb-communications--api-settings .cpb-accordion__cell--actions {
+    display: table-cell;
+}
+
 .cpb-accordion__cell--actions {
     display: flex;
     justify-content: flex-end;
@@ -393,6 +402,10 @@
     gap: 8px;
     width: 120px;
     min-width: 120px;
+    text-align: right;
+}
+
+.cpb-communications--api-settings .cpb-accordion__heading--actions {
     text-align: right;
 }
 

--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -937,3 +937,67 @@
     min-width: 140px;
     text-align: center;
 }
+
+.cpb-error-logs {
+    display: grid;
+    gap: 24px;
+    margin-top: 24px;
+}
+
+.cpb-error-logs__section {
+    background: #fff;
+    border: 1px solid #dcdcde;
+    border-radius: 4px;
+    padding: 20px;
+}
+
+.cpb-error-logs__heading {
+    margin: 0 0 8px;
+    font-size: 18px;
+}
+
+.cpb-error-logs__description {
+    margin: 0 0 16px;
+    color: #50575e;
+}
+
+.cpb-error-logs__empty {
+    margin: 0 0 12px;
+    color: #646970;
+}
+
+.cpb-error-logs__textarea {
+    width: 100%;
+    min-height: 220px;
+    background: #f6f7f7;
+    color: #1d2327;
+    border: 1px solid #c3c4c7;
+    border-radius: 4px;
+    font-family: Menlo, Consolas, Monaco, monospace;
+    font-size: 13px;
+    line-height: 1.5;
+    resize: vertical;
+}
+
+.cpb-error-logs__textarea:focus {
+    border-color: #2271b1;
+    box-shadow: 0 0 0 1px #2271b1;
+}
+
+.cpb-error-logs__actions {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 16px;
+    margin-top: 16px;
+}
+
+.cpb-log-actions__form {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+}
+
+.cpb-log-actions__form .cpb-feedback-area {
+    min-width: 0;
+}

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -1,11 +1,12 @@
 jQuery(document).ready(function($){
     function handleForm(selector, action){
-        var spinnerHideTimer;
         $(selector).on('submit', function(e){
             e.preventDefault();
-            var data = $(this).serialize();
-            var $spinner = $('#cpb-spinner');
-            var $feedback = $('#cpb-feedback');
+            var $form = $(this);
+            var data = $form.serialize();
+            var spinnerHideTimer = $form.data('spinnerHideTimer');
+            var $spinner = $form.find('.cpb-feedback-area .spinner').first();
+            var $feedback = $form.find('.cpb-feedback-area [role="status"]').first();
             if ($feedback.length) {
                 $feedback.removeClass('is-visible').text('');
             }
@@ -31,12 +32,14 @@ jQuery(document).ready(function($){
                     spinnerHideTimer = setTimeout(function(){
                         $spinner.removeClass('is-active');
                     }, 150);
+                    $form.data('spinnerHideTimer', spinnerHideTimer);
                 });
         });
     }
     handleForm('#cpb-create-form','cpb_save_main_entity');
     handleForm('#cpb-general-settings-form','cpb_save_main_entity');
     handleForm('#cpb-style-settings-form','cpb_save_main_entity');
+    handleForm('.cpb-api-settings__form','cpb_save_api_settings');
 
     function formatString(template){
         if (typeof template !== 'string') {

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -744,6 +744,40 @@ jQuery(document).ready(function($){
         $(this).parent().toggleClass('open');
     });
 
+    $(document).on('click', '.cpb-api-settings__toggle-visibility', function(e){
+        e.preventDefault();
+
+        var $button = $(this);
+        var targetSelector = $button.data('target');
+        var $input = targetSelector ? $(targetSelector) : $button.closest('.cpb-api-settings__input-group').find('input').first();
+
+        if (!$input.length) {
+            return;
+        }
+
+        var wasPassword = $input.attr('type') === 'password';
+        var showLabel = $button.data('label-show') || $button.data('labelShow');
+        var hideLabel = $button.data('label-hide') || $button.data('labelHide');
+
+        if (wasPassword) {
+            $input.attr('type', 'text');
+
+            if (hideLabel) {
+                $button.text(hideLabel);
+            }
+
+            $button.attr('aria-pressed', 'true');
+        } else {
+            $input.attr('type', 'password');
+
+            if (showLabel) {
+                $button.text(showLabel);
+            }
+
+            $button.attr('aria-pressed', 'false');
+        }
+    });
+
     function initAccordionGroups(){
         $('[data-cpb-accordion-group]').each(function(){
             var $group = $(this);

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -37,7 +37,7 @@ jQuery(document).ready(function($){
         });
     }
     handleForm('#cpb-create-form','cpb_save_main_entity');
-    handleForm('#cpb-general-settings-form','cpb_save_main_entity');
+    handleForm('#cpb-general-settings-form','cpb_save_general_settings');
     handleForm('#cpb-style-settings-form','cpb_save_main_entity');
     handleForm('.cpb-api-settings__form','cpb_save_api_settings');
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -192,6 +192,7 @@ jQuery(document).ready(function($){
         var $searchForm = $('#cpb-main-entity-search');
         var $searchSpinner = $('#cpb-entity-search-spinner');
         var $searchFeedback = $('#cpb-entity-search-feedback');
+        var $clearSearchButton = $('#cpb-entity-search-clear');
         var placeholderMap = cpbAdmin.placeholderMap || {};
         var placeholderList = Array.isArray(cpbAdmin.placeholders) ? cpbAdmin.placeholders : [];
         var entityFields = Array.isArray(cpbAdmin.entityFields) ? cpbAdmin.entityFields : [];
@@ -847,6 +848,32 @@ jQuery(document).ready(function($){
 
                 currentFilters = newFilters;
                 fetchEntities(1);
+            });
+        }
+
+        if ($clearSearchButton.length){
+            $clearSearchButton.on('click', function(e){
+                e.preventDefault();
+
+                var hadActiveFilters = isSearchActive();
+
+                if ($searchForm.length && typeof $searchForm[0].reset === 'function'){
+                    $searchForm[0].reset();
+                } else if ($searchForm.length){
+                    $searchForm.find('input[type="text"]').val('');
+                }
+
+                currentFilters = {
+                    placeholder_1: '',
+                    placeholder_2: '',
+                    placeholder_3: ''
+                };
+
+                clearSearchFeedback();
+
+                if (hadActiveFilters || currentPage !== 1){
+                    fetchEntities(1);
+                }
             });
         }
 

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -91,7 +91,7 @@ jQuery(document).ready(function($){
                         }
 
                         if (wasSuccessful && logAction === 'download'){
-                            var filename = response.data.filename || 'cpb-error-log.txt';
+                            var filename = response.data.filename || 'cpb-log.txt';
                             var content = typeof response.data.content === 'string' ? response.data.content : '';
                             var blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
                             var url = window.URL.createObjectURL(blob);

--- a/codex-plugin-boilerplate.php
+++ b/codex-plugin-boilerplate.php
@@ -26,6 +26,8 @@ require_once CPB_PLUGIN_DIR . 'includes/class-cpb-i18n.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-main-entity-helper.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-email-template-helper.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-email-log-helper.php';
+require_once CPB_PLUGIN_DIR . 'includes/class-cpb-error-log-helper.php';
+require_once CPB_PLUGIN_DIR . 'includes/class-cpb-error-logger.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-ajax.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-cron.php';
 require_once CPB_PLUGIN_DIR . 'includes/admin/class-cpb-admin.php';

--- a/codex-plugin-boilerplate.php
+++ b/codex-plugin-boilerplate.php
@@ -26,6 +26,7 @@ require_once CPB_PLUGIN_DIR . 'includes/class-cpb-i18n.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-main-entity-helper.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-email-template-helper.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-email-log-helper.php';
+require_once CPB_PLUGIN_DIR . 'includes/class-cpb-settings-helper.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-error-log-helper.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-error-logger.php';
 require_once CPB_PLUGIN_DIR . 'includes/class-cpb-ajax.php';

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -1453,6 +1453,12 @@ class CPB_Admin {
     }
 
     private function render_api_settings_tab() {
+        $saved_settings = get_option( 'cpb_api_settings', array() );
+
+        if ( ! is_array( $saved_settings ) ) {
+            $saved_settings = array();
+        }
+
         $apis = array(
             'payment_gateway' => array(
                 'title'    => __( 'Payment Gateway', 'codex-plugin-boilerplate' ),
@@ -1506,6 +1512,7 @@ class CPB_Admin {
             $form_id    = 'cpb-api-form-' . sanitize_html_class( $api_key );
             $spinner_id = $form_id . '-spinner';
             $feedback_id = $form_id . '-feedback';
+            $saved_api_settings = isset( $saved_settings[ $api_key ] ) && is_array( $saved_settings[ $api_key ] ) ? $saved_settings[ $api_key ] : array();
 
             echo '<tr id="' . esc_attr( $summary_id ) . '" class="cpb-accordion__summary-row" tabindex="0" role="button" aria-expanded="false" aria-controls="' . esc_attr( $panel_id ) . '">';
             echo '<td class="cpb-accordion__cell cpb-accordion__cell--title">';
@@ -1524,34 +1531,38 @@ class CPB_Admin {
             echo '<tr id="' . esc_attr( $panel_id ) . '" class="cpb-accordion__panel-row" role="region" aria-labelledby="' . esc_attr( $summary_id ) . '" aria-hidden="true">';
             echo '<td colspan="3">';
             echo '<div class="cpb-accordion__panel">';
-            echo '<form id="' . esc_attr( $form_id ) . '" class="cpb-api-settings__form">';
+            echo '<form id="' . esc_attr( $form_id ) . '" class="cpb-api-settings__form" method="post">';
+            echo '<input type="hidden" name="cpb_api_key" value="' . esc_attr( $api_key ) . '" />';
             echo '<div class="cpb-api-settings__fields">';
 
             foreach ( $api['fields'] as $field ) {
                 $field_id = $field['name'];
+                $saved_value = isset( $saved_api_settings[ $field['name'] ] ) ? $saved_api_settings[ $field['name'] ] : '';
                 echo '<div class="cpb-api-settings__field">';
                 echo '<label for="' . esc_attr( $field_id ) . '">' . esc_html( $field['label'] ) . '</label>';
 
                 if ( 'select' === $field['type'] ) {
                     echo '<select id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field['name'] ) . '">';
                     foreach ( $field['options'] as $option_value => $option_label ) {
-                        echo '<option value="' . esc_attr( $option_value ) . '">' . esc_html( $option_label ) . '</option>';
+                        $selected = selected( $saved_value, $option_value, false );
+                        echo '<option value="' . esc_attr( $option_value ) . '"' . $selected . '>' . esc_html( $option_label ) . '</option>';
                     }
                     echo '</select>';
                 } else {
                     $input_type = esc_attr( $field['type'] );
                     $input_classes = 'regular-text';
                     $input_attributes = ' id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field['name'] ) . '"';
+                    $input_value = esc_attr( $saved_value );
 
                     if ( ! empty( $field['reveal'] ) ) {
                         $show_label = __( 'Reveal', 'codex-plugin-boilerplate' );
                         $hide_label = __( 'Hide', 'codex-plugin-boilerplate' );
                         echo '<div class="cpb-api-settings__input-group">';
-                        echo '<input type="' . $input_type . '" class="' . esc_attr( $input_classes ) . '"' . $input_attributes . ' autocomplete="off" />';
+                        echo '<input type="' . $input_type . '" class="' . esc_attr( $input_classes ) . '"' . $input_attributes . ' value="' . $input_value . '" autocomplete="off" />';
                         echo '<button type="button" class="button button-secondary cpb-api-settings__toggle-visibility" data-target="#' . esc_attr( $field_id ) . '" data-label-show="' . esc_attr( $show_label ) . '" data-label-hide="' . esc_attr( $hide_label ) . '" aria-pressed="false">' . esc_html( $show_label ) . '</button>';
                         echo '</div>';
                     } else {
-                        echo '<input type="' . $input_type . '" class="' . esc_attr( $input_classes ) . '"' . $input_attributes . ' />';
+                        echo '<input type="' . $input_type . '" class="' . esc_attr( $input_classes ) . '"' . $input_attributes . ' value="' . $input_value . '" />';
                     }
                 }
 

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -2111,10 +2111,6 @@ class CPB_Admin {
 
         $this->render_tab_intro( $title, $description );
 
-        if ( 'payment_logs' === $active_tab ) {
-            $this->render_logging_status_notice( CPB_Settings_Helper::FIELD_LOG_PAYMENTS );
-        }
-
         if ( 'generated_content' === $active_tab ) {
             $this->render_generated_content_log();
         } elseif ( 'error_logs' === $active_tab ) {
@@ -2187,6 +2183,7 @@ class CPB_Admin {
                 /* translators: description for the payment log textarea. */
                 'description' => __( 'Tracks payment gateway notices, API responses, and transaction diagnostics without storing sensitive card data.', 'codex-plugin-boilerplate' ),
                 'empty'       => __( 'No payment activity logged yet.', 'codex-plugin-boilerplate' ),
+                'channel'     => CPB_Settings_Helper::FIELD_LOG_PAYMENTS,
             ),
         );
 

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -763,9 +763,31 @@ class CPB_Admin {
              * @param array $labels Associative array of placeholder slugs to labels.
              */
             $labels = apply_filters( 'cpb_main_entity_placeholder_labels', $labels );
+
+            $labels = $this->sanitize_placeholder_label_map( $labels );
         }
 
         return $labels;
+    }
+
+    private function sanitize_placeholder_label_map( array $labels ) {
+        $sanitized = array();
+
+        foreach ( $labels as $key => $label ) {
+            if ( ! is_scalar( $label ) ) {
+                continue;
+            }
+
+            $normalized = sanitize_text_field( wp_unslash( (string) $label ) );
+
+            if ( '' === $normalized && preg_match( '/^placeholder_(\d+)$/', (string) $key, $matches ) ) {
+                $normalized = sprintf( __( 'Placeholder %d', 'codex-plugin-boilerplate' ), (int) $matches[1] );
+            }
+
+            $sanitized[ $key ] = wp_specialchars_decode( $normalized, ENT_QUOTES );
+        }
+
+        return array_merge( $labels, $sanitized );
     }
 
     private function get_placeholder_label( $index ) {

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -940,6 +940,10 @@ class CPB_Admin {
             'edit'   => __( 'Review saved entities to confirm their data, trigger edits, or remove records you no longer need.', 'codex-plugin-boilerplate' ),
         );
 
+        if ( ! array_key_exists( $active_tab, $tab_titles ) ) {
+            $active_tab = 'create';
+        }
+
         $title       = isset( $tab_titles[ $active_tab ] ) ? $tab_titles[ $active_tab ] : '';
         $description = isset( $tab_descriptions[ $active_tab ] ) ? $tab_descriptions[ $active_tab ] : '';
 
@@ -1395,6 +1399,7 @@ class CPB_Admin {
         echo '<h2 class="nav-tab-wrapper">';
         echo '<a href="?page=cpb-settings&tab=general" class="nav-tab ' . ( 'general' === $active_tab ? 'nav-tab-active' : '' ) . '">' . esc_html__( 'General Settings', 'codex-plugin-boilerplate' ) . '</a>';
         echo '<a href="?page=cpb-settings&tab=style" class="nav-tab ' . ( 'style' === $active_tab ? 'nav-tab-active' : '' ) . '">' . esc_html__( 'Style Settings', 'codex-plugin-boilerplate' ) . '</a>';
+        echo '<a href="?page=cpb-settings&tab=api" class="nav-tab ' . ( 'api' === $active_tab ? 'nav-tab-active' : '' ) . '">' . esc_html__( 'API Settings', 'codex-plugin-boilerplate' ) . '</a>';
         echo '<a href="?page=cpb-settings&tab=cron" class="nav-tab ' . ( 'cron' === $active_tab ? 'nav-tab-active' : '' ) . '">' . esc_html__( 'Cron Jobs', 'codex-plugin-boilerplate' ) . '</a>';
         echo '</h2>';
         $this->top_message_center();
@@ -1402,14 +1407,20 @@ class CPB_Admin {
         $tab_titles = array(
             'general' => __( 'General Settings', 'codex-plugin-boilerplate' ),
             'style'   => __( 'Style Settings', 'codex-plugin-boilerplate' ),
+            'api'     => __( 'API Settings', 'codex-plugin-boilerplate' ),
             'cron'    => __( 'Cron Jobs', 'codex-plugin-boilerplate' ),
         );
 
         $tab_descriptions = array(
             'general' => __( 'Adjust the baseline configuration values that control how Codex Plugin Boilerplate behaves across your site.', 'codex-plugin-boilerplate' ),
             'style'   => __( 'Apply design tweaks and CSS overrides to align the boilerplate output with your brand guidelines.', 'codex-plugin-boilerplate' ),
+            'api'     => __( 'Store external service credentials behind collapsible sections so each integration can be updated without leaving this page.', 'codex-plugin-boilerplate' ),
             'cron'    => __( 'Review and manage every scheduled cron event created by Codex Plugin Boilerplate, including running or deleting hooks on demand.', 'codex-plugin-boilerplate' ),
         );
+
+        if ( ! array_key_exists( $active_tab, $tab_titles ) ) {
+            $active_tab = 'general';
+        }
 
         $title       = isset( $tab_titles[ $active_tab ] ) ? $tab_titles[ $active_tab ] : '';
         $description = isset( $tab_descriptions[ $active_tab ] ) ? $tab_descriptions[ $active_tab ] : '';
@@ -1418,6 +1429,8 @@ class CPB_Admin {
 
         if ( 'style' === $active_tab ) {
             $this->render_style_settings_tab();
+        } elseif ( 'api' === $active_tab ) {
+            $this->render_api_settings_tab();
         } elseif ( 'cron' === $active_tab ) {
             $this->render_cron_jobs_tab();
         } else {
@@ -1437,6 +1450,123 @@ class CPB_Admin {
         echo '<span class="cpb-feedback-area cpb-feedback-area--inline"><span id="cpb-spinner" class="spinner" aria-hidden="true"></span><span id="cpb-feedback" role="status" aria-live="polite"></span></span>';
         echo '</p>';
         echo '</form>';
+    }
+
+    private function render_api_settings_tab() {
+        $apis = array(
+            'payment_gateway' => array(
+                'title'  => __( 'Payment Gateway', 'codex-plugin-boilerplate' ),
+                'fields' => array(
+                    array(
+                        'type'    => 'select',
+                        'name'    => 'payment_gateway_environment',
+                        'label'   => __( 'Environment', 'codex-plugin-boilerplate' ),
+                        'options' => array(
+                            'live'    => __( 'Live', 'codex-plugin-boilerplate' ),
+                            'sandbox' => __( 'Sandbox', 'codex-plugin-boilerplate' ),
+                        ),
+                    ),
+                    array(
+                        'type'  => 'text',
+                        'name'  => 'payment_gateway_login_id',
+                        'label' => __( 'Login ID', 'codex-plugin-boilerplate' ),
+                    ),
+                    array(
+                        'type'    => 'password',
+                        'name'    => 'payment_gateway_transaction_key',
+                        'label'   => __( 'Transaction Key', 'codex-plugin-boilerplate' ),
+                        'reveal'  => true,
+                    ),
+                    array(
+                        'type'    => 'password',
+                        'name'    => 'payment_gateway_client_key',
+                        'label'   => __( 'Client Key', 'codex-plugin-boilerplate' ),
+                        'reveal'  => true,
+                    ),
+                ),
+            ),
+        );
+
+        echo '<div class="cpb-api-settings cpb-communications cpb-communications--api-settings">';
+        echo '<div class="cpb-accordion-group cpb-accordion-group--table" data-cpb-accordion-group="api-settings">';
+        echo '<table class="wp-list-table widefat striped cpb-accordion-table cpb-accordion-table--api">';
+        echo '<thead>';
+        echo '<tr>';
+        echo '<th scope="col" class="cpb-accordion__heading cpb-accordion__heading--title">' . esc_html__( 'API', 'codex-plugin-boilerplate' ) . '</th>';
+        echo '<th scope="col" class="cpb-accordion__heading cpb-accordion__heading--actions">' . esc_html__( 'Actions', 'codex-plugin-boilerplate' ) . '</th>';
+        echo '</tr>';
+        echo '</thead>';
+        echo '<tbody>';
+
+        foreach ( $apis as $api_key => $api ) {
+            $summary_id = 'cpb-api-' . sanitize_html_class( $api_key ) . '-header';
+            $panel_id   = 'cpb-api-' . sanitize_html_class( $api_key ) . '-panel';
+            $form_id    = 'cpb-api-form-' . sanitize_html_class( $api_key );
+            $spinner_id = $form_id . '-spinner';
+            $feedback_id = $form_id . '-feedback';
+
+            echo '<tr id="' . esc_attr( $summary_id ) . '" class="cpb-accordion__summary-row" tabindex="0" role="button" aria-expanded="false" aria-controls="' . esc_attr( $panel_id ) . '">';
+            echo '<td class="cpb-accordion__cell cpb-accordion__cell--title">';
+            echo '<span class="cpb-accordion__title-text">' . esc_html( $api['title'] ) . '</span>';
+            echo '</td>';
+            echo '<td class="cpb-accordion__cell cpb-accordion__cell--actions">';
+            echo '<span class="cpb-accordion__action-link" aria-hidden="true">' . esc_html__( 'Configure', 'codex-plugin-boilerplate' ) . '</span>';
+            echo '<span class="dashicons dashicons-arrow-down-alt2 cpb-accordion__icon" aria-hidden="true"></span>';
+            echo '</td>';
+            echo '</tr>';
+
+            echo '<tr id="' . esc_attr( $panel_id ) . '" class="cpb-accordion__panel-row" role="region" aria-labelledby="' . esc_attr( $summary_id ) . '" aria-hidden="true">';
+            echo '<td colspan="2">';
+            echo '<div class="cpb-accordion__panel">';
+            echo '<form id="' . esc_attr( $form_id ) . '" class="cpb-api-settings__form">';
+            echo '<div class="cpb-api-settings__fields">';
+
+            foreach ( $api['fields'] as $field ) {
+                $field_id = $field['name'];
+                echo '<div class="cpb-api-settings__field">';
+                echo '<label for="' . esc_attr( $field_id ) . '">' . esc_html( $field['label'] ) . '</label>';
+
+                if ( 'select' === $field['type'] ) {
+                    echo '<select id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field['name'] ) . '">';
+                    foreach ( $field['options'] as $option_value => $option_label ) {
+                        echo '<option value="' . esc_attr( $option_value ) . '">' . esc_html( $option_label ) . '</option>';
+                    }
+                    echo '</select>';
+                } else {
+                    $input_type = esc_attr( $field['type'] );
+                    $input_classes = 'regular-text';
+                    $input_attributes = ' id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field['name'] ) . '"';
+
+                    if ( ! empty( $field['reveal'] ) ) {
+                        $show_label = __( 'Reveal', 'codex-plugin-boilerplate' );
+                        $hide_label = __( 'Hide', 'codex-plugin-boilerplate' );
+                        echo '<div class="cpb-api-settings__input-group">';
+                        echo '<input type="' . $input_type . '" class="' . esc_attr( $input_classes ) . '"' . $input_attributes . ' autocomplete="off" />';
+                        echo '<button type="button" class="button button-secondary cpb-api-settings__toggle-visibility" data-target="#' . esc_attr( $field_id ) . '" data-label-show="' . esc_attr( $show_label ) . '" data-label-hide="' . esc_attr( $hide_label ) . '" aria-pressed="false">' . esc_html( $show_label ) . '</button>';
+                        echo '</div>';
+                    } else {
+                        echo '<input type="' . $input_type . '" class="' . esc_attr( $input_classes ) . '"' . $input_attributes . ' />';
+                    }
+                }
+
+                echo '</div>';
+            }
+
+            echo '</div>';
+            $submit_button = get_submit_button( __( 'Save API Settings', 'codex-plugin-boilerplate' ), 'primary', 'submit', false );
+            echo '<p class="submit">' . $submit_button;
+            echo '<span class="cpb-feedback-area cpb-feedback-area--inline"><span id="' . esc_attr( $spinner_id ) . '" class="spinner" aria-hidden="true"></span><span id="' . esc_attr( $feedback_id ) . '" role="status" aria-live="polite"></span></span>';
+            echo '</p>';
+            echo '</form>';
+            echo '</div>';
+            echo '</td>';
+            echo '</tr>';
+        }
+
+        echo '</tbody>';
+        echo '</table>';
+        echo '</div>';
+        echo '</div>';
     }
 
     private function render_style_settings_tab() {

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -1496,9 +1496,68 @@ class CPB_Admin {
     }
 
     private function render_general_settings_tab() {
-        echo '<form id="cpb-general-settings-form">';
-        echo '<label>' . esc_html__( 'Option', 'codex-plugin-boilerplate' ) . ' <span class="cpb-tooltip-icon dashicons dashicons-editor-help" data-tooltip="' . esc_attr__( 'Tooltip placeholder text for Option', 'codex-plugin-boilerplate' ) . '"></span></label>';
-        echo '<input type="text" name="option" />';
+        $settings = CPB_Settings_Helper::get_general_settings();
+
+        $logging_fields = array(
+            CPB_Settings_Helper::FIELD_LOG_EMAIL => array(
+                'label'       => __( 'Email Logs', 'codex-plugin-boilerplate' ),
+                'description' => __( 'Capture email delivery activity so you can audit messages from the Email Logs tab.', 'codex-plugin-boilerplate' ),
+            ),
+            CPB_Settings_Helper::FIELD_LOG_SMS => array(
+                'label'       => __( 'SMS Logs', 'codex-plugin-boilerplate' ),
+                'description' => __( 'Store outbound SMS activity for future messaging diagnostics.', 'codex-plugin-boilerplate' ),
+            ),
+            CPB_Settings_Helper::FIELD_LOG_SITE_ERRORS => array(
+                'label'       => __( 'Sitewide errors, notices, and warnings', 'codex-plugin-boilerplate' ),
+                'description' => __( 'Record PHP notices from the entire site inside the Error Logs tab.', 'codex-plugin-boilerplate' ),
+            ),
+            CPB_Settings_Helper::FIELD_LOG_PLUGIN_ERRORS => array(
+                'label'       => __( 'Errors, notices, and warnings specific to this plugin only', 'codex-plugin-boilerplate' ),
+                'description' => __( 'Limit error tracking to issues related to Codex Plugin Boilerplate for targeted troubleshooting.', 'codex-plugin-boilerplate' ),
+            ),
+            CPB_Settings_Helper::FIELD_LOG_PAYMENTS => array(
+                'label'       => __( 'Payment logs', 'codex-plugin-boilerplate' ),
+                'description' => __( 'Retain payment gateway diagnostics and transaction context within the Payment Logs tab.', 'codex-plugin-boilerplate' ),
+            ),
+        );
+
+        echo '<form id="cpb-general-settings-form" class="cpb-settings-form">';
+        echo '<table class="form-table" role="presentation">';
+
+        $option_tooltip = esc_attr__( 'Tooltip placeholder text for Option', 'codex-plugin-boilerplate' );
+        $option_value   = isset( $settings[ CPB_Settings_Helper::FIELD_OPTION ] ) ? $settings[ CPB_Settings_Helper::FIELD_OPTION ] : '';
+
+        echo '<tr>';
+        echo '<th scope="row">';
+        echo '<label for="cpb-general-option">' . esc_html__( 'Option', 'codex-plugin-boilerplate' ) . ' <span class="cpb-tooltip-icon dashicons dashicons-editor-help" data-tooltip="' . $option_tooltip . '"></span></label>';
+        echo '</th>';
+        echo '<td>';
+        echo '<input type="text" id="cpb-general-option" name="' . esc_attr( CPB_Settings_Helper::FIELD_OPTION ) . '" value="' . esc_attr( $option_value ) . '" class="regular-text" />';
+        echo '</td>';
+        echo '</tr>';
+
+        foreach ( $logging_fields as $field_key => $field ) {
+            $field_id   = 'cpb-general-' . str_replace( '_', '-', $field_key );
+            $is_enabled = ! empty( $settings[ $field_key ] );
+
+            echo '<tr>';
+            echo '<th scope="row">' . esc_html( $field['label'] ) . '</th>';
+            echo '<td>';
+            echo '<label for="' . esc_attr( $field_id ) . '">';
+            echo '<input type="checkbox" id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field_key ) . '" value="1" ' . checked( $is_enabled, true, false ) . ' />';
+            echo ' ' . esc_html__( 'Enable logging', 'codex-plugin-boilerplate' );
+            echo '</label>';
+
+            if ( ! empty( $field['description'] ) ) {
+                echo '<p class="description">' . esc_html( $field['description'] ) . '</p>';
+            }
+
+            echo '</td>';
+            echo '</tr>';
+        }
+
+        echo '</table>';
+
         $submit_button = get_submit_button( __( 'Save Settings', 'codex-plugin-boilerplate' ), 'primary', 'submit', false );
         echo '<p class="submit">' . $submit_button;
         echo '<span class="cpb-feedback-area cpb-feedback-area--inline"><span id="cpb-spinner" class="spinner" aria-hidden="true"></span><span id="cpb-feedback" role="status" aria-live="polite"></span></span>';

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -1408,6 +1408,7 @@ class CPB_Admin {
         echo '</div>';
         echo '<div class="cpb-entity-search__actions">';
         echo '<button type="submit" class="button button-primary">' . esc_html__( 'Search', 'codex-plugin-boilerplate' ) . '</button>';
+        echo '<button type="button" id="cpb-entity-search-clear" class="button button-secondary">' . esc_html__( 'Clear Search', 'codex-plugin-boilerplate' ) . '</button>';
         echo '<span class="cpb-feedback-area cpb-feedback-area--inline">';
         echo '<span id="cpb-entity-search-spinner" class="spinner" aria-hidden="true"></span>';
         echo '<span id="cpb-entity-search-feedback" role="status" aria-live="polite"></span>';

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -741,6 +741,7 @@ class CPB_Admin {
             'emailLogError'     => __( 'Unable to clear the email log. Please try again.', 'codex-plugin-boilerplate' ),
             'emailLogEmpty'     => __( 'No email activity has been recorded yet.', 'codex-plugin-boilerplate' ),
             'logDownloadReady'  => __( 'Log download ready.', 'codex-plugin-boilerplate' ),
+            'searchFiltersApplied' => __( 'Showing filtered results.', 'codex-plugin-boilerplate' ),
         ) );
     }
 
@@ -1385,6 +1386,35 @@ class CPB_Admin {
         $column_count = 6; // Five placeholder columns plus actions.
 
         echo '<div class="cpb-communications cpb-communications--main-entities">';
+        echo '<div class="cpb-entity-search" role="search">';
+        echo '<form id="cpb-main-entity-search" class="cpb-entity-search__form" method="post">';
+        echo '<h3 class="cpb-entity-search__title">' . esc_html__( 'Search Main Entities', 'codex-plugin-boilerplate' ) . '</h3>';
+        echo '<p class="cpb-entity-search__description">' . esc_html__( 'Filter records by placeholder values to quickly locate the entries you need.', 'codex-plugin-boilerplate' ) . '</p>';
+        echo '<div class="cpb-entity-search__fields">';
+
+        for ( $i = 1; $i <= 3; $i++ ) {
+            $field_key = 'placeholder_' . $i;
+            $label     = $this->get_placeholder_label( $i );
+            $field_id  = 'cpb-entity-search-' . $field_key;
+
+            echo '<div class="cpb-entity-search__field">';
+            echo '<label class="cpb-entity-search__label" for="' . esc_attr( $field_id ) . '">';
+            echo esc_html( $label );
+            echo '</label>';
+            echo '<input type="text" id="' . esc_attr( $field_id ) . '" name="' . esc_attr( $field_key ) . '" class="regular-text" />';
+            echo '</div>';
+        }
+
+        echo '</div>';
+        echo '<div class="cpb-entity-search__actions">';
+        echo '<button type="submit" class="button button-primary">' . esc_html__( 'Search', 'codex-plugin-boilerplate' ) . '</button>';
+        echo '<span class="cpb-feedback-area cpb-feedback-area--inline">';
+        echo '<span id="cpb-entity-search-spinner" class="spinner" aria-hidden="true"></span>';
+        echo '<span id="cpb-entity-search-feedback" role="status" aria-live="polite"></span>';
+        echo '</span>';
+        echo '</div>';
+        echo '</form>';
+        echo '</div>';
         echo '<div class="cpb-accordion-group cpb-accordion-group--table" data-cpb-accordion-group="main-entities">';
         echo '<table class="wp-list-table widefat striped cpb-accordion-table">';
         echo '<thead>';

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -1455,7 +1455,8 @@ class CPB_Admin {
     private function render_api_settings_tab() {
         $apis = array(
             'payment_gateway' => array(
-                'title'  => __( 'Payment Gateway', 'codex-plugin-boilerplate' ),
+                'title'    => __( 'Payment Gateway', 'codex-plugin-boilerplate' ),
+                'category' => __( 'Payments', 'codex-plugin-boilerplate' ),
                 'fields' => array(
                     array(
                         'type'    => 'select',
@@ -1493,6 +1494,7 @@ class CPB_Admin {
         echo '<thead>';
         echo '<tr>';
         echo '<th scope="col" class="cpb-accordion__heading cpb-accordion__heading--title">' . esc_html__( 'API', 'codex-plugin-boilerplate' ) . '</th>';
+        echo '<th scope="col" class="cpb-accordion__heading cpb-accordion__heading--category">' . esc_html__( 'Category', 'codex-plugin-boilerplate' ) . '</th>';
         echo '<th scope="col" class="cpb-accordion__heading cpb-accordion__heading--actions">' . esc_html__( 'Actions', 'codex-plugin-boilerplate' ) . '</th>';
         echo '</tr>';
         echo '</thead>';
@@ -1509,6 +1511,10 @@ class CPB_Admin {
             echo '<td class="cpb-accordion__cell cpb-accordion__cell--title">';
             echo '<span class="cpb-accordion__title-text">' . esc_html( $api['title'] ) . '</span>';
             echo '</td>';
+            echo '<td class="cpb-accordion__cell cpb-accordion__cell--category">';
+            $category = isset( $api['category'] ) ? $api['category'] : '';
+            echo $category ? esc_html( $category ) : '&mdash;';
+            echo '</td>';
             echo '<td class="cpb-accordion__cell cpb-accordion__cell--actions">';
             echo '<span class="cpb-accordion__action-link" aria-hidden="true">' . esc_html__( 'Configure', 'codex-plugin-boilerplate' ) . '</span>';
             echo '<span class="dashicons dashicons-arrow-down-alt2 cpb-accordion__icon" aria-hidden="true"></span>';
@@ -1516,7 +1522,7 @@ class CPB_Admin {
             echo '</tr>';
 
             echo '<tr id="' . esc_attr( $panel_id ) . '" class="cpb-accordion__panel-row" role="region" aria-labelledby="' . esc_attr( $summary_id ) . '" aria-hidden="true">';
-            echo '<td colspan="2">';
+            echo '<td colspan="3">';
             echo '<div class="cpb-accordion__panel">';
             echo '<form id="' . esc_attr( $form_id ) . '" class="cpb-api-settings__form">';
             echo '<div class="cpb-api-settings__fields">';

--- a/includes/admin/class-cpb-admin.php
+++ b/includes/admin/class-cpb-admin.php
@@ -1492,6 +1492,55 @@ class CPB_Admin {
                     ),
                 ),
             ),
+            'sms_service' => array(
+                'title'    => __( 'SMS Service', 'codex-plugin-boilerplate' ),
+                'category' => __( 'Messaging', 'codex-plugin-boilerplate' ),
+                'fields'   => array(
+                    array(
+                        'type'    => 'select',
+                        'name'    => 'sms_environment',
+                        'label'   => __( 'Environment', 'codex-plugin-boilerplate' ),
+                        'options' => array(
+                            'live'    => __( 'Live', 'codex-plugin-boilerplate' ),
+                            'sandbox' => __( 'Sandbox', 'codex-plugin-boilerplate' ),
+                        ),
+                    ),
+                    array(
+                        'type'   => 'password',
+                        'name'   => 'sms_messaging_service_sid',
+                        'label'  => __( 'Messaging Service SID', 'codex-plugin-boilerplate' ),
+                        'reveal' => true,
+                    ),
+                    array(
+                        'type'  => 'text',
+                        'name'  => 'sms_sending_number',
+                        'label' => __( 'Sending Number', 'codex-plugin-boilerplate' ),
+                    ),
+                    array(
+                        'type'  => 'text',
+                        'name'  => 'sms_sandbox_number',
+                        'label' => __( 'Sandbox Number', 'codex-plugin-boilerplate' ),
+                    ),
+                    array(
+                        'type'   => 'password',
+                        'name'   => 'sms_user_sid',
+                        'label'  => __( 'User SID', 'codex-plugin-boilerplate' ),
+                        'reveal' => true,
+                    ),
+                    array(
+                        'type'   => 'password',
+                        'name'   => 'sms_api_sid',
+                        'label'  => __( 'API SID', 'codex-plugin-boilerplate' ),
+                        'reveal' => true,
+                    ),
+                    array(
+                        'type'   => 'password',
+                        'name'   => 'sms_api_key',
+                        'label'  => __( 'API Key', 'codex-plugin-boilerplate' ),
+                        'reveal' => true,
+                    ),
+                ),
+            ),
         );
 
         echo '<div class="cpb-api-settings cpb-communications cpb-communications--api-settings">';

--- a/includes/class-cpb-ajax.php
+++ b/includes/class-cpb-ajax.php
@@ -711,7 +711,7 @@ class CPB_Ajax {
             $value = implode( ',', $value );
         }
 
-        return sanitize_text_field( $value );
+        return $this->normalize_plain_text( $value );
     }
 
     private function replace_template_tokens( $content, $tokens ) {
@@ -912,7 +912,7 @@ class CPB_Ajax {
 
         if ( is_array( $value ) ) {
             foreach ( $value as $item ) {
-                $item = sanitize_text_field( $item );
+                $item = $this->normalize_plain_text( $item );
 
                 if ( '' !== $item ) {
                     $items[] = $item;
@@ -924,7 +924,7 @@ class CPB_Ajax {
 
             if ( is_array( $split ) ) {
                 foreach ( $split as $item ) {
-                    $item = trim( $item );
+                    $item = $this->normalize_plain_text( $item );
 
                     if ( '' !== $item ) {
                         $items[] = $item;
@@ -934,6 +934,24 @@ class CPB_Ajax {
         }
 
         return wp_json_encode( $items );
+    }
+
+    private function normalize_plain_text( $value ) {
+        if ( null === $value ) {
+            return '';
+        }
+
+        if ( is_array( $value ) ) {
+            $value = reset( $value );
+        }
+
+        $value = sanitize_text_field( (string) wp_unslash( $value ) );
+
+        if ( '' === $value ) {
+            return '';
+        }
+
+        return wp_specialchars_decode( $value, ENT_QUOTES );
     }
 
     private function sanitize_color_value( $key ) {

--- a/includes/class-cpb-ajax.php
+++ b/includes/class-cpb-ajax.php
@@ -157,6 +157,33 @@ class CPB_Ajax {
                     ),
                 ),
             ),
+            'sms_service' => array(
+                'fields' => array(
+                    'sms_environment' => array(
+                        'type'    => 'select',
+                        'options' => array( 'live', 'sandbox' ),
+                        'default' => 'live',
+                    ),
+                    'sms_messaging_service_sid' => array(
+                        'type' => 'text',
+                    ),
+                    'sms_sending_number' => array(
+                        'type' => 'text',
+                    ),
+                    'sms_sandbox_number' => array(
+                        'type' => 'text',
+                    ),
+                    'sms_user_sid' => array(
+                        'type' => 'text',
+                    ),
+                    'sms_api_sid' => array(
+                        'type' => 'text',
+                    ),
+                    'sms_api_key' => array(
+                        'type' => 'text',
+                    ),
+                ),
+            ),
         );
 
         if ( ! $api_key || ! isset( $api_definitions[ $api_key ] ) ) {

--- a/includes/class-cpb-ajax.php
+++ b/includes/class-cpb-ajax.php
@@ -27,7 +27,12 @@ class CPB_Ajax {
         $elapsed = microtime( true ) - $start;
 
         if ( $elapsed < $minimum_time ) {
-            usleep( ( $minimum_time - $elapsed ) * 1000000 );
+            $remaining    = $minimum_time - $elapsed;
+            $microseconds = (int) ceil( max( 0, $remaining ) * 1000000 );
+
+            if ( $microseconds > 0 ) {
+                usleep( $microseconds );
+            }
         }
     }
 
@@ -275,9 +280,11 @@ class CPB_Ajax {
             );
         }
 
-        $message = ( CPB_Error_Log_Helper::SCOPE_PLUGIN === $scope )
-            ? __( 'CPB error log cleared.', 'codex-plugin-boilerplate' )
-            : __( 'Sitewide error log cleared.', 'codex-plugin-boilerplate' );
+        $message = CPB_Error_Log_Helper::get_clear_success_message( $scope );
+
+        if ( '' === $message ) {
+            $message = __( 'Log cleared.', 'codex-plugin-boilerplate' );
+        }
 
         $this->maybe_delay( $start );
         wp_send_json_success(

--- a/includes/class-cpb-email-log-helper.php
+++ b/includes/class-cpb-email-log-helper.php
@@ -93,6 +93,10 @@ class CPB_Email_Log_Helper {
      * @return bool
      */
     public static function log_email( array $args ) {
+        if ( ! CPB_Settings_Helper::is_logging_enabled( CPB_Settings_Helper::FIELD_LOG_EMAIL ) ) {
+            return false;
+        }
+
         $path = self::get_log_file_path();
 
         if ( '' === $path ) {

--- a/includes/class-cpb-error-log-helper.php
+++ b/includes/class-cpb-error-log-helper.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * Utility helpers for storing and retrieving CPB error logs.
+ *
+ * @package Codex_Plugin_Boilerplate
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CPB_Error_Log_Helper {
+
+    const SCOPE_SITEWIDE = 'sitewide';
+    const SCOPE_PLUGIN   = 'plugin';
+
+    /**
+     * Mapping of scopes to log filenames.
+     *
+     * @var array<string, string>
+     */
+    protected static $filenames = array(
+        self::SCOPE_SITEWIDE => 'cpb-sitewide-errors.log',
+        self::SCOPE_PLUGIN   => 'cpb-plugin-errors.log',
+    );
+
+    /**
+     * Cached log file paths keyed by scope.
+     *
+     * @var array<string, string>
+     */
+    protected static $paths = array();
+
+    /**
+     * Retrieve the filesystem path for the requested log scope.
+     *
+     * Ensures the upload directory exists and the log file is seeded.
+     *
+     * @param string $scope Log scope identifier.
+     *
+     * @return string Log file path or empty string on failure.
+     */
+    public static function get_log_file_path( $scope ) {
+        $scope = self::normalize_scope( $scope );
+
+        if ( '' === $scope ) {
+            return '';
+        }
+
+        if ( isset( self::$paths[ $scope ] ) ) {
+            return self::$paths[ $scope ];
+        }
+
+        $upload_dir = wp_upload_dir();
+
+        if ( ! empty( $upload_dir['error'] ) ) {
+            return '';
+        }
+
+        $directory = trailingslashit( $upload_dir['basedir'] ) . 'cpb-logs';
+
+        /**
+         * Filter the base directory used to store error logs.
+         *
+         * @since 0.1.0
+         *
+         * @param string $directory  Absolute directory path.
+         * @param array  $upload_dir Upload directory information from {@see wp_upload_dir()}.
+         * @param string $scope      Error log scope.
+         */
+        $directory = apply_filters( 'cpb_error_log_directory', $directory, $upload_dir, $scope );
+        $directory = untrailingslashit( $directory );
+
+        if ( '' === $directory ) {
+            return '';
+        }
+
+        if ( ! wp_mkdir_p( $directory ) ) {
+            return '';
+        }
+
+        $filename = self::$filenames[ $scope ];
+        $path     = trailingslashit( $directory ) . $filename;
+
+        if ( ! file_exists( $path ) ) {
+            $handle = @fopen( $path, 'a' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+
+            if ( ! $handle ) {
+                return '';
+            }
+
+            fclose( $handle );
+        }
+
+        self::$paths[ $scope ] = $path;
+
+        return $path;
+    }
+
+    /**
+     * Append an error entry to the requested log file.
+     *
+     * @param string $scope Log scope identifier.
+     * @param array  $entry Log details.
+     *
+     * @return bool
+     */
+    public static function append_entry( $scope, array $entry ) {
+        $path = self::get_log_file_path( $scope );
+
+        if ( '' === $path ) {
+            return false;
+        }
+
+        $formatted = self::format_entry( $entry );
+
+        if ( '' === $formatted ) {
+            return false;
+        }
+
+        $result = file_put_contents( $path, $formatted, FILE_APPEND | LOCK_EX ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents
+
+        return false !== $result;
+    }
+
+    /**
+     * Generate a formatted log entry.
+     *
+     * @param array $entry Log data.
+     *
+     * @return string
+     */
+    public static function format_entry( array $entry ) {
+        $timestamp = isset( $entry['timestamp'] ) ? self::sanitize_line( $entry['timestamp'] ) : gmdate( 'c' );
+        $label     = isset( $entry['label'] ) ? self::sanitize_line( $entry['label'] ) : __( 'Notice', 'codex-plugin-boilerplate' );
+        $severity  = isset( $entry['severity'] ) ? self::sanitize_line( $entry['severity'] ) : '';
+        $message   = isset( $entry['message'] ) ? self::normalize_multiline( $entry['message'] ) : '';
+        $file      = isset( $entry['file'] ) ? self::sanitize_line( $entry['file'] ) : '';
+        $line      = isset( $entry['line'] ) ? (int) $entry['line'] : 0;
+        $stack     = isset( $entry['stack'] ) ? self::normalize_multiline( $entry['stack'] ) : '';
+        $scope     = isset( $entry['scope'] ) ? self::sanitize_line( $entry['scope'] ) : '';
+
+        $lines = array(
+            '=== Error Logged ===',
+            'Timestamp (UTC): ' . $timestamp,
+            'Type: ' . $label,
+        );
+
+        if ( '' !== $severity ) {
+            $lines[] = 'PHP Severity: ' . $severity;
+        }
+
+        if ( '' !== $scope ) {
+            $lines[] = 'Captured Scope: ' . $scope;
+        }
+
+        $lines[] = 'Message:';
+        $lines[] = $message ? $message : '—';
+
+        if ( '' !== $file ) {
+            $lines[] = 'File: ' . $file;
+        }
+
+        if ( $line > 0 ) {
+            $lines[] = 'Line: ' . $line;
+        }
+
+        if ( '' !== $stack ) {
+            $lines[] = 'Stack Trace:';
+            $lines[] = $stack;
+        }
+
+        $lines[] = '=== End Error Logged ===';
+        $lines[] = '';
+
+        return implode( "\n", $lines );
+    }
+
+    /**
+     * Retrieve the raw contents of a log file.
+     *
+     * @param string $scope Log scope identifier.
+     *
+     * @return string
+     */
+    public static function get_log_contents( $scope ) {
+        $path = self::get_log_file_path( $scope );
+
+        if ( '' === $path ) {
+            return '';
+        }
+
+        $contents = file_get_contents( $path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_file_get_contents
+
+        if ( false === $contents ) {
+            return '';
+        }
+
+        return (string) $contents;
+    }
+
+    /**
+     * Clear a log file while keeping it available for future writes.
+     *
+     * @param string $scope Log scope identifier.
+     *
+     * @return bool
+     */
+    public static function clear_log( $scope ) {
+        $path = self::get_log_file_path( $scope );
+
+        if ( '' === $path ) {
+            return false;
+        }
+
+        $handle = @fopen( $path, 'w' ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fopen
+
+        if ( ! $handle ) {
+            return false;
+        }
+
+        fclose( $handle );
+
+        return true;
+    }
+
+    /**
+     * Retrieve the suggested download filename for a scope.
+     *
+     * @param string $scope Log scope identifier.
+     *
+     * @return string
+     */
+    public static function get_download_filename( $scope ) {
+        $scope = self::normalize_scope( $scope );
+
+        if ( '' === $scope ) {
+            return '';
+        }
+
+        return self::$filenames[ $scope ];
+    }
+
+    /**
+     * Normalize the provided scope to a known value.
+     *
+     * @param string $scope Raw scope value.
+     *
+     * @return string
+     */
+    public static function normalize_scope( $scope ) {
+        $scope = sanitize_key( $scope );
+
+        if ( isset( self::$filenames[ $scope ] ) ) {
+            return $scope;
+        }
+
+        return '';
+    }
+
+    /**
+     * Provide a human-readable label for a scope.
+     *
+     * @param string $scope Log scope identifier.
+     *
+     * @return string
+     */
+    public static function get_scope_label( $scope ) {
+        $scope = self::normalize_scope( $scope );
+
+        switch ( $scope ) {
+            case self::SCOPE_PLUGIN:
+                return __( 'CPB-Related', 'codex-plugin-boilerplate' );
+            case self::SCOPE_SITEWIDE:
+                return __( 'Sitewide', 'codex-plugin-boilerplate' );
+        }
+
+        return '';
+    }
+
+    /**
+     * Sanitize a single-line string for storage.
+     *
+     * @param string $value Raw string.
+     *
+     * @return string
+     */
+    protected static function sanitize_line( $value ) {
+        $value = (string) $value;
+        $value = wp_strip_all_tags( $value );
+        $value = preg_replace( "/[\r\n]+/", ' ', $value );
+
+        return trim( $value );
+    }
+
+    /**
+     * Normalize multiline text by removing disallowed tags and standardizing newlines.
+     *
+     * @param string $value Raw multiline string.
+     *
+     * @return string
+     */
+    protected static function normalize_multiline( $value ) {
+        $value = (string) $value;
+        $value = wp_strip_all_tags( $value );
+        $value = preg_replace( "/\\r\\n?/", "\\n", $value );
+        $value = preg_replace( "/\\n{3,}/", "\\n\\n", $value );
+
+        return trim( $value );
+    }
+}
+

--- a/includes/class-cpb-error-log-helper.php
+++ b/includes/class-cpb-error-log-helper.php
@@ -108,6 +108,16 @@ class CPB_Error_Log_Helper {
      * @return bool
      */
     public static function append_entry( $scope, array $entry ) {
+        $scope = self::normalize_scope( $scope );
+
+        if ( '' === $scope ) {
+            return false;
+        }
+
+        if ( ! self::is_scope_enabled( $scope ) ) {
+            return false;
+        }
+
         $path = self::get_log_file_path( $scope );
 
         if ( '' === $path ) {
@@ -302,6 +312,26 @@ class CPB_Error_Log_Helper {
         }
 
         return '';
+    }
+
+    /**
+     * Determine whether the provided scope is permitted to write entries.
+     *
+     * @param string $scope Normalized log scope identifier.
+     *
+     * @return bool
+     */
+    protected static function is_scope_enabled( $scope ) {
+        switch ( $scope ) {
+            case self::SCOPE_SITEWIDE:
+                return CPB_Settings_Helper::is_logging_enabled( CPB_Settings_Helper::FIELD_LOG_SITE_ERRORS );
+            case self::SCOPE_PLUGIN:
+                return CPB_Settings_Helper::is_logging_enabled( CPB_Settings_Helper::FIELD_LOG_PLUGIN_ERRORS );
+            case self::SCOPE_PAYMENTS:
+                return CPB_Settings_Helper::is_logging_enabled( CPB_Settings_Helper::FIELD_LOG_PAYMENTS );
+        }
+
+        return true;
     }
 
     /**

--- a/includes/class-cpb-error-log-helper.php
+++ b/includes/class-cpb-error-log-helper.php
@@ -335,14 +335,53 @@ class CPB_Error_Log_Helper {
     }
 
     /**
+     * Convert arbitrary values to a printable string.
+     *
+     * @param mixed $value Raw value.
+     *
+     * @return string
+     */
+    protected static function stringify_value( $value ) {
+        if ( is_string( $value ) ) {
+            return $value;
+        }
+
+        if ( null === $value ) {
+            return '';
+        }
+
+        if ( is_scalar( $value ) ) {
+            return (string) $value;
+        }
+
+        if ( $value instanceof \Throwable ) {
+            return $value->getMessage();
+        }
+
+        if ( is_object( $value ) && method_exists( $value, '__toString' ) ) {
+            return (string) $value;
+        }
+
+        $encoded = wp_json_encode( $value );
+
+        if ( is_string( $encoded ) ) {
+            return $encoded;
+        }
+
+        $printed = print_r( $value, true );
+
+        return is_string( $printed ) ? $printed : '';
+    }
+
+    /**
      * Sanitize a single-line string for storage.
      *
-     * @param string $value Raw string.
+     * @param mixed $value Raw string.
      *
      * @return string
      */
     protected static function sanitize_line( $value ) {
-        $value = (string) $value;
+        $value = self::stringify_value( $value );
         $value = wp_strip_all_tags( $value );
         $value = preg_replace( "/[\r\n]+/", ' ', $value );
 
@@ -352,12 +391,12 @@ class CPB_Error_Log_Helper {
     /**
      * Normalize multiline text by removing disallowed tags and standardizing newlines.
      *
-     * @param string $value Raw multiline string.
+     * @param mixed $value Raw multiline string.
      *
      * @return string
      */
     protected static function normalize_multiline( $value ) {
-        $value = (string) $value;
+        $value = self::stringify_value( $value );
         $value = wp_strip_all_tags( $value );
         $value = preg_replace( "/\\r\\n?/", "\\n", $value );
         $value = preg_replace( "/\\n{3,}/", "\\n\\n", $value );

--- a/includes/class-cpb-error-log-helper.php
+++ b/includes/class-cpb-error-log-helper.php
@@ -13,6 +13,7 @@ class CPB_Error_Log_Helper {
 
     const SCOPE_SITEWIDE = 'sitewide';
     const SCOPE_PLUGIN   = 'plugin';
+    const SCOPE_PAYMENTS = 'payments';
 
     /**
      * Mapping of scopes to log filenames.
@@ -22,6 +23,7 @@ class CPB_Error_Log_Helper {
     protected static $filenames = array(
         self::SCOPE_SITEWIDE => 'cpb-sitewide-errors.log',
         self::SCOPE_PLUGIN   => 'cpb-plugin-errors.log',
+        self::SCOPE_PAYMENTS => 'cpb-payment-activity.log',
     );
 
     /**
@@ -242,6 +244,28 @@ class CPB_Error_Log_Helper {
     }
 
     /**
+     * Retrieve the success message shown after clearing a log scope.
+     *
+     * @param string $scope Log scope identifier.
+     *
+     * @return string
+     */
+    public static function get_clear_success_message( $scope ) {
+        $scope = self::normalize_scope( $scope );
+
+        switch ( $scope ) {
+            case self::SCOPE_PLUGIN:
+                return __( 'CPB error log cleared.', 'codex-plugin-boilerplate' );
+            case self::SCOPE_SITEWIDE:
+                return __( 'Sitewide error log cleared.', 'codex-plugin-boilerplate' );
+            case self::SCOPE_PAYMENTS:
+                return __( 'Payment log cleared.', 'codex-plugin-boilerplate' );
+        }
+
+        return '';
+    }
+
+    /**
      * Normalize the provided scope to a known value.
      *
      * @param string $scope Raw scope value.
@@ -273,6 +297,8 @@ class CPB_Error_Log_Helper {
                 return __( 'CPB-Related', 'codex-plugin-boilerplate' );
             case self::SCOPE_SITEWIDE:
                 return __( 'Sitewide', 'codex-plugin-boilerplate' );
+            case self::SCOPE_PAYMENTS:
+                return __( 'Payment', 'codex-plugin-boilerplate' );
         }
 
         return '';

--- a/includes/class-cpb-error-logger.php
+++ b/includes/class-cpb-error-logger.php
@@ -362,12 +362,14 @@ class CPB_Error_Logger {
         $message    = isset( $entry['message'] ) ? $entry['message'] : '';
         $stack      = isset( $entry['stack'] ) ? $entry['stack'] : '';
         $is_plugin  = $this->is_plugin_related( $file, $message, $stack );
-        $site_entry = $entry;
-        $site_entry['scope'] = CPB_Error_Log_Helper::get_scope_label( CPB_Error_Log_Helper::SCOPE_SITEWIDE );
-        CPB_Error_Log_Helper::append_entry( CPB_Error_Log_Helper::SCOPE_SITEWIDE, $site_entry );
+        if ( CPB_Settings_Helper::is_logging_enabled( CPB_Settings_Helper::FIELD_LOG_SITE_ERRORS ) ) {
+            $site_entry           = $entry;
+            $site_entry['scope'] = CPB_Error_Log_Helper::get_scope_label( CPB_Error_Log_Helper::SCOPE_SITEWIDE );
+            CPB_Error_Log_Helper::append_entry( CPB_Error_Log_Helper::SCOPE_SITEWIDE, $site_entry );
+        }
 
-        if ( $is_plugin ) {
-            $plugin_entry         = $entry;
+        if ( $is_plugin && CPB_Settings_Helper::is_logging_enabled( CPB_Settings_Helper::FIELD_LOG_PLUGIN_ERRORS ) ) {
+            $plugin_entry          = $entry;
             $plugin_entry['scope'] = CPB_Error_Log_Helper::get_scope_label( CPB_Error_Log_Helper::SCOPE_PLUGIN );
             CPB_Error_Log_Helper::append_entry( CPB_Error_Log_Helper::SCOPE_PLUGIN, $plugin_entry );
         }

--- a/includes/class-cpb-error-logger.php
+++ b/includes/class-cpb-error-logger.php
@@ -1,0 +1,485 @@
+<?php
+/**
+ * Capture PHP and WordPress notices for the CPB log screens.
+ *
+ * @package Codex_Plugin_Boilerplate
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CPB_Error_Logger {
+
+    /**
+     * Previously registered PHP error handler.
+     *
+     * @var callable|null
+     */
+    protected $previous_error_handler = null;
+
+    /**
+     * Previously registered exception handler.
+     *
+     * @var callable|null
+     */
+    protected $previous_exception_handler = null;
+
+    /**
+     * Normalized plugin directory path for scope checks.
+     *
+     * @var string
+     */
+    protected $plugin_dir = '';
+
+    public function __construct() {
+        if ( defined( 'CPB_PLUGIN_DIR' ) ) {
+            $this->plugin_dir = wp_normalize_path( CPB_PLUGIN_DIR );
+        }
+    }
+
+    /**
+     * Register all logging hooks.
+     */
+    public function register() {
+        $this->previous_error_handler     = set_error_handler( array( $this, 'handle_error' ) );
+        $this->previous_exception_handler = set_exception_handler( array( $this, 'handle_exception' ) );
+
+        register_shutdown_function( array( $this, 'handle_shutdown' ) );
+
+        add_action( 'doing_it_wrong_run', array( $this, 'handle_doing_it_wrong' ), 10, 3 );
+        add_action( 'deprecated_function_run', array( $this, 'handle_deprecated_function' ), 10, 3 );
+        add_action( 'deprecated_argument_run', array( $this, 'handle_deprecated_argument' ), 10, 4 );
+        add_action( 'deprecated_hook_run', array( $this, 'handle_deprecated_hook' ), 10, 4 );
+        add_action( 'deprecated_file_included', array( $this, 'handle_deprecated_file' ), 10, 4 );
+    }
+
+    /**
+     * PHP error handler proxy.
+     *
+     * @param int    $errno   Error number.
+     * @param string $errstr  Error message.
+     * @param string $errfile File path.
+     * @param int    $errline Line number.
+     *
+     * @return bool
+     */
+    public function handle_error( $errno, $errstr, $errfile = '', $errline = 0 ) {
+        if ( 0 === error_reporting() ) {
+            // Respect suppressed errors (@ operator).
+            return $this->call_previous_error_handler( $errno, $errstr, $errfile, $errline );
+        }
+
+        $this->log_php_error( $errno, $errstr, $errfile, $errline );
+
+        return $this->call_previous_error_handler( $errno, $errstr, $errfile, $errline );
+    }
+
+    /**
+     * Exception handler proxy.
+     *
+     * @param Throwable $exception Captured exception/throwable.
+     */
+    public function handle_exception( $exception ) {
+        $message = sprintf(
+            /* translators: %s: exception class name */
+            __( 'Uncaught %s encountered.', 'codex-plugin-boilerplate' ),
+            is_object( $exception ) ? get_class( $exception ) : __( 'exception', 'codex-plugin-boilerplate' )
+        );
+
+        $this->log_event(
+            array(
+                'label'    => __( 'Exception', 'codex-plugin-boilerplate' ),
+                'severity' => 'E_EXCEPTION',
+                'message'  => $message . ' ' . $exception->getMessage(),
+                'file'     => $exception->getFile(),
+                'line'     => $exception->getLine(),
+                'stack'    => $exception->getTraceAsString(),
+            )
+        );
+
+        if ( $this->previous_exception_handler ) {
+            call_user_func( $this->previous_exception_handler, $exception );
+        }
+    }
+
+    /**
+     * Shutdown handler to catch fatal errors.
+     */
+    public function handle_shutdown() {
+        $error = error_get_last();
+
+        if ( empty( $error ) ) {
+            return;
+        }
+
+        $fatal_types = array(
+            E_ERROR,
+            E_PARSE,
+            E_CORE_ERROR,
+            E_COMPILE_ERROR,
+            E_USER_ERROR,
+        );
+
+        if ( isset( $error['type'] ) && in_array( $error['type'], $fatal_types, true ) ) {
+            $this->log_php_error( $error['type'], $error['message'], $error['file'], $error['line'], true );
+        }
+    }
+
+    /**
+     * Log "doing it wrong" warnings.
+     *
+     * @param string $function Function name.
+     * @param string $message  Warning message.
+     * @param string $version  Version details.
+     */
+    public function handle_doing_it_wrong( $function, $message, $version ) {
+        $formatted = sprintf(
+            /* translators: 1: function name, 2: version, 3: message */
+            __( 'Function %1$s was called incorrectly (since %2$s): %3$s', 'codex-plugin-boilerplate' ),
+            $function,
+            $version,
+            $message
+        );
+
+        $this->log_event(
+            array(
+                'label'    => __( 'Incorrect Usage', 'codex-plugin-boilerplate' ),
+                'severity' => 'doing_it_wrong',
+                'message'  => $formatted,
+                'stack'    => $this->get_stack_summary(),
+            )
+        );
+    }
+
+    /**
+     * Log deprecated function usage.
+     *
+     * @param string $function Function name.
+     * @param string $replacement Replacement suggestion.
+     * @param string $version Version deprecated.
+     */
+    public function handle_deprecated_function( $function, $replacement, $version ) {
+        $message = $this->format_deprecated_message( __( 'Function', 'codex-plugin-boilerplate' ), $function, $replacement, $version );
+
+        $this->log_event(
+            array(
+                'label'    => __( 'Deprecated Function', 'codex-plugin-boilerplate' ),
+                'severity' => 'deprecated_function',
+                'message'  => $message,
+                'stack'    => $this->get_stack_summary(),
+            )
+        );
+    }
+
+    /**
+     * Log deprecated argument usage.
+     */
+    public function handle_deprecated_argument( $function, $message, $version, $replacement = null ) {
+        $summary = sprintf(
+            /* translators: 1: function name, 2: version, 3: message */
+            __( 'Argument used by %1$s is deprecated since %2$s: %3$s', 'codex-plugin-boilerplate' ),
+            $function,
+            $version,
+            $message
+        );
+
+        if ( $replacement ) {
+            $summary .= ' ' . sprintf(
+                /* translators: %s: replacement suggestion */
+                __( 'Use %s instead.', 'codex-plugin-boilerplate' ),
+                $replacement
+            );
+        }
+
+        $this->log_event(
+            array(
+                'label'    => __( 'Deprecated Argument', 'codex-plugin-boilerplate' ),
+                'severity' => 'deprecated_argument',
+                'message'  => $summary,
+                'stack'    => $this->get_stack_summary(),
+            )
+        );
+    }
+
+    /**
+     * Log deprecated hook usage.
+     */
+    public function handle_deprecated_hook( $hook, $message, $version, $replacement = null ) {
+        $summary = sprintf(
+            /* translators: 1: hook name, 2: version, 3: message */
+            __( 'Hook %1$s is deprecated since %2$s: %3$s', 'codex-plugin-boilerplate' ),
+            $hook,
+            $version,
+            $message
+        );
+
+        if ( $replacement ) {
+            $summary .= ' ' . sprintf(
+                /* translators: %s: replacement hook */
+                __( 'Use %s instead.', 'codex-plugin-boilerplate' ),
+                $replacement
+            );
+        }
+
+        $this->log_event(
+            array(
+                'label'    => __( 'Deprecated Hook', 'codex-plugin-boilerplate' ),
+                'severity' => 'deprecated_hook',
+                'message'  => $summary,
+                'stack'    => $this->get_stack_summary(),
+            )
+        );
+    }
+
+    /**
+     * Log deprecated file usage.
+     */
+    public function handle_deprecated_file( $file, $replacement, $version, $message ) {
+        $summary = sprintf(
+            /* translators: 1: file path, 2: version, 3: message */
+            __( 'File %1$s is deprecated since %2$s: %3$s', 'codex-plugin-boilerplate' ),
+            $file,
+            $version,
+            $message
+        );
+
+        if ( $replacement ) {
+            $summary .= ' ' . sprintf(
+                /* translators: %s: replacement file */
+                __( 'Use %s instead.', 'codex-plugin-boilerplate' ),
+                $replacement
+            );
+        }
+
+        $this->log_event(
+            array(
+                'label'    => __( 'Deprecated File', 'codex-plugin-boilerplate' ),
+                'severity' => 'deprecated_file',
+                'message'  => $summary,
+                'stack'    => $this->get_stack_summary(),
+            )
+        );
+    }
+
+    /**
+     * Send a PHP error to the logging system.
+     *
+     * @param int    $errno   Error number.
+     * @param string $errstr  Message.
+     * @param string $errfile File path.
+     * @param int    $errline Line number.
+     * @param bool   $is_fatal Whether triggered from shutdown handler.
+     */
+    protected function log_php_error( $errno, $errstr, $errfile, $errline, $is_fatal = false ) {
+        $label = $this->map_error_label( $errno, $is_fatal );
+        $stack = $this->get_stack_summary();
+
+        $this->log_event(
+            array(
+                'label'    => $label,
+                'severity' => $this->map_error_constant( $errno ),
+                'message'  => $errstr,
+                'file'     => $errfile,
+                'line'     => $errline,
+                'stack'    => $stack,
+            )
+        );
+    }
+
+    /**
+     * Map PHP error numbers to human-readable labels.
+     *
+     * @param int  $errno   Error number.
+     * @param bool $is_fatal Whether triggered during shutdown.
+     *
+     * @return string
+     */
+    protected function map_error_label( $errno, $is_fatal = false ) {
+        $map = array(
+            E_ERROR             => __( 'Fatal Error', 'codex-plugin-boilerplate' ),
+            E_WARNING           => __( 'Warning', 'codex-plugin-boilerplate' ),
+            E_PARSE             => __( 'Parse Error', 'codex-plugin-boilerplate' ),
+            E_NOTICE            => __( 'Notice', 'codex-plugin-boilerplate' ),
+            E_CORE_ERROR        => __( 'Core Error', 'codex-plugin-boilerplate' ),
+            E_CORE_WARNING      => __( 'Core Warning', 'codex-plugin-boilerplate' ),
+            E_COMPILE_ERROR     => __( 'Compile Error', 'codex-plugin-boilerplate' ),
+            E_COMPILE_WARNING   => __( 'Compile Warning', 'codex-plugin-boilerplate' ),
+            E_USER_ERROR        => __( 'User Error', 'codex-plugin-boilerplate' ),
+            E_USER_WARNING      => __( 'User Warning', 'codex-plugin-boilerplate' ),
+            E_USER_NOTICE       => __( 'User Notice', 'codex-plugin-boilerplate' ),
+            E_STRICT            => __( 'Strict Notice', 'codex-plugin-boilerplate' ),
+            E_RECOVERABLE_ERROR => __( 'Recoverable Error', 'codex-plugin-boilerplate' ),
+            E_DEPRECATED        => __( 'Deprecated Notice', 'codex-plugin-boilerplate' ),
+            E_USER_DEPRECATED   => __( 'User Deprecated Notice', 'codex-plugin-boilerplate' ),
+        );
+
+        if ( isset( $map[ $errno ] ) ) {
+            return $map[ $errno ];
+        }
+
+        return $is_fatal ? __( 'Fatal Error', 'codex-plugin-boilerplate' ) : __( 'Notice', 'codex-plugin-boilerplate' );
+    }
+
+    /**
+     * Convert PHP error numbers to their constant names when possible.
+     *
+     * @param int $errno Error number.
+     *
+     * @return string
+     */
+    protected function map_error_constant( $errno ) {
+        $constants = array(
+            E_ERROR             => 'E_ERROR',
+            E_WARNING           => 'E_WARNING',
+            E_PARSE             => 'E_PARSE',
+            E_NOTICE            => 'E_NOTICE',
+            E_CORE_ERROR        => 'E_CORE_ERROR',
+            E_CORE_WARNING      => 'E_CORE_WARNING',
+            E_COMPILE_ERROR     => 'E_COMPILE_ERROR',
+            E_COMPILE_WARNING   => 'E_COMPILE_WARNING',
+            E_USER_ERROR        => 'E_USER_ERROR',
+            E_USER_WARNING      => 'E_USER_WARNING',
+            E_USER_NOTICE       => 'E_USER_NOTICE',
+            E_STRICT            => 'E_STRICT',
+            E_RECOVERABLE_ERROR => 'E_RECOVERABLE_ERROR',
+            E_DEPRECATED        => 'E_DEPRECATED',
+            E_USER_DEPRECATED   => 'E_USER_DEPRECATED',
+        );
+
+        return isset( $constants[ $errno ] ) ? $constants[ $errno ] : 'E_UNKNOWN';
+    }
+
+    /**
+     * Write an event to one or more log scopes.
+     *
+     * @param array $entry Entry data.
+     */
+    protected function log_event( array $entry ) {
+        $entry['timestamp'] = gmdate( 'c' );
+
+        $file       = isset( $entry['file'] ) ? $entry['file'] : '';
+        $message    = isset( $entry['message'] ) ? $entry['message'] : '';
+        $stack      = isset( $entry['stack'] ) ? $entry['stack'] : '';
+        $is_plugin  = $this->is_plugin_related( $file, $message, $stack );
+        $site_entry = $entry;
+        $site_entry['scope'] = CPB_Error_Log_Helper::get_scope_label( CPB_Error_Log_Helper::SCOPE_SITEWIDE );
+        CPB_Error_Log_Helper::append_entry( CPB_Error_Log_Helper::SCOPE_SITEWIDE, $site_entry );
+
+        if ( $is_plugin ) {
+            $plugin_entry         = $entry;
+            $plugin_entry['scope'] = CPB_Error_Log_Helper::get_scope_label( CPB_Error_Log_Helper::SCOPE_PLUGIN );
+            CPB_Error_Log_Helper::append_entry( CPB_Error_Log_Helper::SCOPE_PLUGIN, $plugin_entry );
+        }
+    }
+
+    /**
+     * Determine whether the error is related to this plugin.
+     *
+     * @param string $file    File path.
+     * @param string $message Message text.
+     * @param string $stack   Stack trace.
+     *
+     * @return bool
+     */
+    protected function is_plugin_related( $file, $message, $stack ) {
+        if ( $file ) {
+            $file = wp_normalize_path( $file );
+
+            if ( $this->plugin_dir && 0 === strpos( $file, $this->plugin_dir ) ) {
+                return true;
+            }
+        }
+
+        $keywords = array(
+            'codex-plugin-boilerplate',
+            'cpb_',
+            'CPB_',
+        );
+
+        foreach ( $keywords as $keyword ) {
+            if ( false !== stripos( $message, $keyword ) ) {
+                return true;
+            }
+
+            if ( $stack && false !== stripos( $stack, $keyword ) ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Format deprecated notices consistently.
+     *
+     * @param string      $type        Type label.
+     * @param string      $subject     Deprecated element.
+     * @param string|null $replacement Replacement suggestion.
+     * @param string      $version     Version.
+     *
+     * @return string
+     */
+    protected function format_deprecated_message( $type, $subject, $replacement, $version ) {
+        $message = sprintf(
+            /* translators: 1: deprecated type, 2: name, 3: version */
+            __( '%1$s %2$s is deprecated since %3$s.', 'codex-plugin-boilerplate' ),
+            $type,
+            $subject,
+            $version
+        );
+
+        if ( $replacement ) {
+            $message .= ' ' . sprintf(
+                /* translators: %s: replacement */
+                __( 'Use %s instead.', 'codex-plugin-boilerplate' ),
+                $replacement
+            );
+        }
+
+        return $message;
+    }
+
+    /**
+     * Retrieve a summary of the current call stack.
+     *
+     * @return string
+     */
+    protected function get_stack_summary() {
+        if ( function_exists( 'wp_debug_backtrace_summary' ) ) {
+            return wp_debug_backtrace_summary( null, 0, false );
+        }
+
+        $trace = debug_backtrace( DEBUG_BACKTRACE_IGNORE_ARGS );
+        $lines = array();
+
+        foreach ( $trace as $frame ) {
+            if ( isset( $frame['file'], $frame['line'] ) ) {
+                $lines[] = $frame['file'] . ':' . $frame['line'];
+            } elseif ( isset( $frame['function'] ) ) {
+                $lines[] = $frame['function'];
+            }
+        }
+
+        return implode( ' <- ', $lines );
+    }
+
+    /**
+     * Forward errors to the previously registered handler when available.
+     *
+     * @param int    $errno   Error number.
+     * @param string $errstr  Error message.
+     * @param string $errfile File path.
+     * @param int    $errline Line number.
+     *
+     * @return bool
+     */
+    protected function call_previous_error_handler( $errno, $errstr, $errfile, $errline ) {
+        if ( $this->previous_error_handler ) {
+            return (bool) call_user_func( $this->previous_error_handler, $errno, $errstr, $errfile, $errline );
+        }
+
+        return false;
+    }
+}
+

--- a/includes/class-cpb-error-logger.php
+++ b/includes/class-cpb-error-logger.php
@@ -393,6 +393,9 @@ class CPB_Error_Logger {
             }
         }
 
+        $message = $this->stringify_for_match( $message );
+        $stack   = $this->stringify_for_match( $stack );
+
         $keywords = array(
             'codex-plugin-boilerplate',
             'cpb_',
@@ -410,6 +413,39 @@ class CPB_Error_Logger {
         }
 
         return false;
+    }
+
+    /**
+     * Normalize arbitrary values to strings for keyword matching.
+     *
+     * @param mixed $value Potentially non-string value.
+     *
+     * @return string
+     */
+    protected function stringify_for_match( $value ) {
+        if ( is_string( $value ) ) {
+            return $value;
+        }
+
+        if ( null === $value ) {
+            return '';
+        }
+
+        if ( is_scalar( $value ) ) {
+            return (string) $value;
+        }
+
+        if ( $value instanceof \Throwable ) {
+            return $value->getMessage();
+        }
+
+        if ( is_object( $value ) && method_exists( $value, '__toString' ) ) {
+            return (string) $value;
+        }
+
+        $encoded = wp_json_encode( $value );
+
+        return is_string( $encoded ) ? $encoded : '';
     }
 
     /**

--- a/includes/class-cpb-plugin.php
+++ b/includes/class-cpb-plugin.php
@@ -14,6 +14,7 @@ class CPB_Plugin {
     private $block;
     private $content_logger;
     private $cron_manager;
+    private $error_logger;
 
     public function __construct() {
         $this->i18n     = new CPB_I18n();
@@ -23,10 +24,12 @@ class CPB_Plugin {
         $this->block          = new CPB_Block_Main_Entity();
         $this->content_logger = new CPB_Content_Logger();
         $this->cron_manager   = new CPB_Cron_Manager();
+        $this->error_logger   = new CPB_Error_Logger();
     }
 
     public function run() {
         $this->i18n->load_textdomain();
+        $this->error_logger->register();
         $this->admin->register();
         $this->ajax->register();
         $this->shortcode->register();

--- a/includes/class-cpb-settings-helper.php
+++ b/includes/class-cpb-settings-helper.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Helper utilities for storing and retrieving general plugin settings.
+ *
+ * @package Codex_Plugin_Boilerplate
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CPB_Settings_Helper {
+
+    const OPTION_NAME = 'cpb_general_settings';
+
+    const FIELD_OPTION            = 'option';
+    const FIELD_LOG_EMAIL         = 'log_email';
+    const FIELD_LOG_SMS           = 'log_sms';
+    const FIELD_LOG_SITE_ERRORS   = 'log_site_errors';
+    const FIELD_LOG_PLUGIN_ERRORS = 'log_plugin_errors';
+    const FIELD_LOG_PAYMENTS      = 'log_payments';
+
+    /**
+     * Retrieve all stored general settings merged with defaults.
+     *
+     * @return array
+     */
+    public static function get_general_settings() {
+        $stored   = get_option( self::OPTION_NAME, array() );
+        $defaults = self::get_default_settings();
+
+        if ( ! is_array( $stored ) ) {
+            $stored = array();
+        }
+
+        return wp_parse_args( $stored, $defaults );
+    }
+
+    /**
+     * Retrieve default general settings.
+     *
+     * @return array
+     */
+    public static function get_default_settings() {
+        return array(
+            self::FIELD_OPTION            => '',
+            self::FIELD_LOG_EMAIL         => true,
+            self::FIELD_LOG_SMS           => true,
+            self::FIELD_LOG_SITE_ERRORS   => true,
+            self::FIELD_LOG_PLUGIN_ERRORS => true,
+            self::FIELD_LOG_PAYMENTS      => true,
+        );
+    }
+
+    /**
+     * Persist sanitized general settings.
+     *
+     * @param array $settings Raw settings.
+     *
+     * @return bool
+     */
+    public static function save_general_settings( array $settings ) {
+        $sanitized = self::sanitize_general_settings( $settings );
+
+        return update_option( self::OPTION_NAME, $sanitized );
+    }
+
+    /**
+     * Sanitize the provided general settings.
+     *
+     * @param array $settings Raw settings.
+     *
+     * @return array
+     */
+    public static function sanitize_general_settings( array $settings ) {
+        $defaults = self::get_default_settings();
+        $sanitized = $defaults;
+
+        if ( isset( $settings[ self::FIELD_OPTION ] ) ) {
+            $sanitized[ self::FIELD_OPTION ] = sanitize_text_field( wp_unslash( $settings[ self::FIELD_OPTION ] ) );
+        }
+
+        $toggle_fields = array(
+            self::FIELD_LOG_EMAIL,
+            self::FIELD_LOG_SMS,
+            self::FIELD_LOG_SITE_ERRORS,
+            self::FIELD_LOG_PLUGIN_ERRORS,
+            self::FIELD_LOG_PAYMENTS,
+        );
+
+        foreach ( $toggle_fields as $field ) {
+            $sanitized[ $field ] = ! empty( $settings[ $field ] );
+        }
+
+        return $sanitized;
+    }
+
+    /**
+     * Determine whether a given logging channel is enabled.
+     *
+     * @param string $channel Channel identifier (one of the FIELD_LOG_* constants).
+     *
+     * @return bool
+     */
+    public static function is_logging_enabled( $channel ) {
+        $settings = self::get_general_settings();
+
+        if ( ! isset( $settings[ $channel ] ) ) {
+            return false;
+        }
+
+        return (bool) $settings[ $channel ];
+    }
+}


### PR DESCRIPTION
## Summary
- add an API Settings tab to the CPB settings page with a payment gateway accordion row and per-integration save controls
- style the new credential form layout and wire up reveal toggles for sensitive keys
- document the change in the development diary

## Testing
- find . -name "*.php" -not -path "*/vendor/*" -print0 | xargs -0 -n1 php -l

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911c425a2888320b86bea17fd934385)